### PR TITLE
Accept options override

### DIFF
--- a/lib/qrcode-draw.js
+++ b/lib/qrcode-draw.js
@@ -43,7 +43,7 @@ QRCodeDraw.prototype = {
   QRErrorCorrectLevel:QRCodeLib.QRErrorCorrectLevel,
   draw:function(canvas,text,options,cb){
     var cb,
-        options = {},
+        options,
         level,
         error;
 
@@ -51,6 +51,7 @@ QRCodeDraw.prototype = {
     var args = Array.prototype.slice.call(arguments);
     cb = args.pop(); 
     canvas = args.shift();
+    text  = args.shift();
     options = args.shift()||{};
 
     


### PR DESCRIPTION
`options` are currently discarded by draw, and there we cannot customize QR error corrections and other options.
