### PR TITLE
Do not use latest node-canvas version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	"qrcode":"./bin/qrcode"
  }
  ,"dependencies": {
-   "canvas": ">= 0.4.3",
+   "canvas": ">= 0.4.3 <=1.0.4",
    "colors":"*"
  }
  ,"devDependencies":{


### PR DESCRIPTION
The latest version of node-canvas breaks horribly on a lot of installations because of the introduction of features which aren't present in the cairo library being used without a lot of cumbersome hackery.

Restricting canvas to 1.0.4 seems to alleviate these problems.
