### PR TITLE
add browser field of browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "barcode"
   ],
   "main": "./qrcode.js",
+  "browser":"./lib/qrcode-draw.js",
   "homepage": "http://github.com/soldair/node-qrcode",
   "scripts": {
     "pretest": "node build.js",


### PR DESCRIPTION
This module can be required via `require('qrcode')` as usual when using Browserify.
