### PR TITLE
Update node-canvas version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "qrcode": "./bin/qrcode"
   },
   "dependencies": {
-    "canvas": "~1.1.6",
+    "canvas": "~1.2.9",
     "colors": "*",
     "bops": "0.0.6"
   },


### PR DESCRIPTION
Update node-canvas version to `1.2.9` to get the compatibility with NodeJS 4.0.0