### PR TITLE
Update READMD to fix installation issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ npm install -g qrcode
  On ubuntu you can install them with `apt-get` and `npm install` will work great.
   
 ```shell
-sudo apt-get install libpixman-1-dev libcairo2-dev libpangocairo-1.0-0 libpango1.0-dev
+sudo apt-get install libpixman-1-dev libcairo2-dev libpangocairo-1.0-0 libpango1.0-dev libgif-dev
 ```
 It is my higest priority for this module to use an all `js` png encoder and remove this dep.
 


### PR DESCRIPTION
When build node-qrcode, it need `libgif-dev`. But the doc doesn't mention it.

Change:

```
sudo apt-get install libpixman-1-dev libcairo2-dev libpangocairo-1.0-0 libpango1.0-dev
```

To:

```
sudo apt-get install libpixman-1-dev libcairo2-dev libpangocairo-1.0-0 libpango1.0-dev libgif-dev
```