### PR TITLE
Add support for command line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,25 +44,32 @@ npm install -g qrcode
 ## Usage
 ### CLI
 
-```shell
-qrcode <text> [output file]
 ```
-Output image format is detected from file extension.<br>
-Supported format are `png`, `svg` and `txt`.
+Usage: qrcode [options] <input string>
 
-If no output file is specified, the QR Code will be rendered directly in the terminal.
+QR Code options:
+  -v, --version  QR Code symbol version (1 - 40)
+  -e, --error    Error correction level            [choices: "L", "M", "Q", "H"]
+  -m, --mask     Mask pattern (0 - 7)
 
-#### Example
+Renderer options:
+  -t, --type        Output type                  [choices: "png", "svg", "utf8"]
+  -s, --scale       Scale factor
+  -q, --qzone       Quiet zone size
+  -l, --lightcolor  Light RGBA hex color
+  -d, --darkcolor   Dark RGBA hex color
 
-```shell
-qrcode "Draw a QR Code in my terminal"
+Options:
+  -o, --output  Output file
+  -h, --help    Show help                                              [boolean]
+
+Examples:
+  qrcode "some text"                    Draw in terminal window
+  qrcode -o out.png "some text"         Save as png image
+  qrcode -d F00 -o out.png "some text"  Use red as foreground color
 ```
-```shell
-qrcode "I like to save qrs as a PNG" qr.png
-```
-```shell
-qrcode "I also like to save them as a SVG" qr.svg
-```
+If not specified, output type is guessed from file extension.<br>
+Recognized extensions are `png`, `svg` and `txt`.
 
 ### Browser
 `node-qrcode` can be used in browser through module bundlers like [Browserify](https://github.com/substack/node-browserify) and [Webpack](https://github.com/webpack/webpack) or by including the precompiled bundle present in `build/` folder.

--- a/bin/qrcode
+++ b/bin/qrcode
@@ -1,34 +1,110 @@
 #!/usr/bin/env node
+var yargs = require('yargs')
+var qr = require('../lib')
 
-try {
-  var qr = require('../lib')
-} catch (e) {
-  qr = require('qrcode')
+function save (file, text, options) {
+  qr.toFile(file, text, options, function (err, data) {
+    if (err) {
+      console.error('Error:', err.message)
+      process.exit(1)
+    }
+
+    console.log('saved qrcode to: ' + file + '\n')
+  })
 }
 
-var text = process.argv[2]
-var file = process.argv[3]
+function print (text, options) {
+  options.type = 'terminal'
+  qr.toString(text, options, function (err, text) {
+    if (err) {
+      console.error('Error:', err.message)
+      process.exit(1)
+    }
 
-if (text && text.length) {
-  if (file && file.length) {
-    qr.toFile(file, text, function (err, data) {
-      if (!err) {
-        process.stdout.write('saved qrcode to: ' + file + '\n')
-      } else {
-        process.stderr.write('failed to save qrcode\n')
-        throw err
-      }
-    })
-  } else {
-    qr.toString(text, { type: 'terminal' }, function (error, text) {
-      if (error) {
-        throw new Error(error)
-      }
+    console.log(text)
+    console.log('\n')
+  })
+}
 
-      process.stdout.write(text)
-      process.stdout.write('\n')
-    })
+function parseOptions (args) {
+  return {
+    version: args.version,
+    errorCorrectionLevel: args.error,
+    type: args.type,
+    maskPattern: args.mask,
+    margin: args.qzone,
+    scale: args.scale,
+    color: {
+      light: args.lightcolor,
+      dark: args.darkcolor
+    }
   }
+}
+
+var argv = yargs
+  .detectLocale(false)
+  .usage('Usage: $0 [options] <input string>')
+  .option('v', {
+    alias: 'version',
+    description: 'QR Code symbol version (1 - 40)',
+    group: 'QR Code options:'
+  })
+  .option('e', {
+    alias: 'error',
+    description: 'Error correction level',
+    choices: ['L', 'M', 'Q', 'H'],
+    group: 'QR Code options:'
+  })
+  .option('m', {
+    alias: 'mask',
+    description: 'Mask pattern (0 - 7)',
+    group: 'QR Code options:'
+  })
+  .option('t', {
+    alias: 'type',
+    description: 'Output type',
+    choices: ['png', 'svg', 'utf8'],
+    implies: 'output',
+    group: 'Renderer options:'
+  })
+  .option('s', {
+    alias: 'scale',
+    description: 'Scale factor',
+    group: 'Renderer options:'
+  })
+  .option('q', {
+    alias: 'qzone',
+    description: 'Quiet zone size',
+    group: 'Renderer options:'
+  })
+  .option('l', {
+    alias: 'lightcolor',
+    description: 'Light RGBA hex color',
+    group: 'Renderer options:'
+  })
+  .option('d', {
+    alias: 'darkcolor',
+    description: 'Dark RGBA hex color',
+    group: 'Renderer options:'
+  })
+  .option('o', {
+    alias: 'output',
+    description: 'Output file'
+  })
+  .help('h')
+  .alias('h', 'help')
+  .example('$0 "some text"', 'Draw in terminal window')
+  .example('$0 -o out.png "some text"', 'Save as png image')
+  .example('$0 -d F00 -o out.png "some text"', 'Use red as foreground color')
+  .argv
+
+if (!argv._.length) {
+  yargs.showHelp()
+  process.exit(1)
+}
+
+if (argv.output) {
+  save(argv.output, argv._.join(' '), parseOptions(argv))
 } else {
-  process.stderr.write('text\n\trequired as first argument.\nfile name [optional]\n\tto save png or svg qrcode may be provided as optional second argument\n')
+  print(argv._.join(' '), parseOptions(argv))
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "colors": "*",
     "dijkstrajs": "^1.0.1",
     "isarray": "^2.0.1",
-    "pngjs": "^2.3.1"
+    "pngjs": "^2.3.1",
+    "yargs": "^8.0.2"
   },
   "devDependencies": {
     "browserify": "^14.1.0",


### PR DESCRIPTION
Allows to set options also through CLI utility.

Help screen:

```
Usage: qrcode [options] <input string>

QR Code options:
  -v, --version  QR Code symbol version (1 - 40)
  -e, --error    Error correction level            [choices: "L", "M", "Q", "H"]

Renderer options:
  -t, --type        Output type                  [choices: "png", "svg", "utf8"]
  -s, --scale       Scale factor
  -q, --qzone       Quiet zone size
  -l, --lightcolor  Light RGBA hex color
  -d, --darkcolor   Dark RGBA hex color

Options:
  -o, --output  Output file
  -h, --help    Show help                                              [boolean]

Examples:
  qrcode "some text"                    Draw in terminal window
  qrcode -o out.png "some text"         Save as png image
  qrcode -d F00 -o out.png "some text"  Use red as foreground color
```