### PR TITLE
Fix error event not emitted when using toFileStream api

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Server:
 - [toDataURL()](todataurltext-options-cberror-url-1)
 - [toString()](#tostringtext-options-cberror-string-1)
 - [toFile()](#tofilepath-text-options-cberror)
-- [toFileStream()](#tofilestreamstream-text-options-cberror)
+- [toFileStream()](#tofilestreamstream-text-options)
 
 ### Browser API
 #### `create(text, [options])`
@@ -575,7 +575,7 @@ QRCode.toFile('path/to/filename.png', 'Some text', {
 
 <br>
 
-#### `toFileStream(stream, text, [options], cb(error))`
+#### `toFileStream(stream, text, [options])`
 Writes QR Code image to stream. Only works with `png` format for now.
 
 ##### `stream`
@@ -590,11 +590,6 @@ Text to encode or a list of objects describing segments.
 
 ##### `options`
 See [Options](#options).
-
-##### `cb`
-Type: `Function`
-
-Callback function called on finish.
 
 <br>
 

--- a/lib/core/qrcode.js
+++ b/lib/core/qrcode.js
@@ -394,7 +394,7 @@ function createSymbol (data, version, errorCorrectionLevel) {
 
     // Build optimized segments
     // If estimated version is undefined, try with the highest version
-    segments = Segments.fromString(data, estimatedVersion)
+    segments = Segments.fromString(data, estimatedVersion || 40)
   } else {
     throw new Error('Invalid data')
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -103,8 +103,8 @@ exports.toFileStream = function toFileStream (stream, text, opts) {
     throw new Error('Too few arguments provided')
   }
 
-  var params = checkParams(text, opts || {}, function () {})
-  var renderer = getRendererFromType(params.opts.type)
+  var params = checkParams(text, opts, stream.emit.bind(stream, 'error'))
+  var renderer = getRendererFromType('png') // Only png support for now
   var renderToFileStream = renderer.renderToFileStream.bind(null, stream)
   render(renderToFileStream, text, params)
 }

--- a/test/e2e/toFileStream.test.js
+++ b/test/e2e/toFileStream.test.js
@@ -13,11 +13,6 @@ test('toFileStream png', function (t) {
   var fstream = new StreamMock()
   var spy = sinon.spy(fstream, 'emit')
 
-  QRCode.toFileStream(fstream, 'i am a pony!', {
-    version: 1, // force version=1 to trigger an error
-    errorCorrectionLevel: 'H'
-  })
-
   QRCode.toFileStream(fstream, 'i am a pony!')
 
   QRCode.toFileStream(fstream, 'i am a pony!', {
@@ -38,6 +33,23 @@ test('toFileStream png with write error', function (t) {
   t.plan(2)
 
   fstreamErr.on('error', function (e) {
-    t.ok(e)
+    t.ok(e, 'Should return an error')
+  })
+})
+
+test('toFileStream png with qrcode error', function (t) {
+  var fstreamErr = new StreamMock()
+  var bigString = Array(200).join('i am a pony!')
+
+  t.plan(2)
+
+  fstreamErr.on('error', function (e) {
+    t.ok(e, 'Should return an error')
+  })
+
+  QRCode.toFileStream(fstreamErr, bigString)
+  QRCode.toFileStream(fstreamErr, 'i am a pony!', {
+    version: 1, // force version=1 to trigger an error
+    errorCorrectionLevel: 'H'
   })
 })


### PR DESCRIPTION
An error event is now emitted when something throws.

```javascript
// Example
const qr = require('qrcode')
const fs = require('fs')

const fstream = fs.createWriteStream('./qrcode.png');

fstream.on('error', (err) => {
  console.error(err.message)
  fstream.end()
})

qr.toFileStream(fstream, text)
```

Closes #83 