### PR TITLE
Fix Buffer to work with IE9

### DIFF
--- a/lib/renderer/utils.js
+++ b/lib/renderer/utils.js
@@ -64,7 +64,7 @@ exports.qrToImageData = function qrToImageData (imgData, qr, margin, scale, colo
         i < symbolSize - scaledMargin && j < symbolSize - scaledMargin) {
         var iSrc = Math.floor((i - scaledMargin) / scale)
         var jSrc = Math.floor((j - scaledMargin) / scale)
-        pxColor = palette[data[iSrc * size + jSrc]]
+        pxColor = palette[data[iSrc * size + jSrc] ? 1 : 0]
       }
 
       imgData[posDst++] = pxColor.r

--- a/lib/utils/typedarray-buffer.js
+++ b/lib/utils/typedarray-buffer.js
@@ -9,28 +9,49 @@
 
 var isArray = require('isarray')
 
-var K_MAX_LENGTH = 0x7fffffff
-
-function Buffer (arg, offset, length) {
-  if (typeof arg === 'number') {
-    return allocUnsafe(arg)
+function typedArraySupport () {
+  // Can typed array instances be augmented?
+  try {
+    var arr = new Uint8Array(1)
+    arr.__proto__ = {__proto__: Uint8Array.prototype, foo: function () { return 42 }}
+    return arr.foo() === 42
+  } catch (e) {
+    return false
   }
-
-  return from(arg, offset, length)
 }
 
-Buffer.prototype.__proto__ = Uint8Array.prototype
-Buffer.__proto__ = Uint8Array
+Buffer.TYPED_ARRAY_SUPPORT = typedArraySupport()
 
-// Fix subarray() in ES2016. See: https://github.com/feross/buffer/pull/97
-if (typeof Symbol !== 'undefined' && Symbol.species &&
-    Buffer[Symbol.species] === Buffer) {
-  Object.defineProperty(Buffer, Symbol.species, {
-    value: null,
-    configurable: true,
-    enumerable: false,
-    writable: false
-  })
+var K_MAX_LENGTH = Buffer.TYPED_ARRAY_SUPPORT
+    ? 0x7fffffff
+    : 0x3fffffff
+
+function Buffer (arg, offset, length) {
+  if (!Buffer.TYPED_ARRAY_SUPPORT && !(this instanceof Buffer)) {
+    return new Buffer(arg, offset, length)
+  }
+
+  if (typeof arg === 'number') {
+    return allocUnsafe(this, arg)
+  }
+
+  return from(this, arg, offset, length)
+}
+
+if (Buffer.TYPED_ARRAY_SUPPORT) {
+  Buffer.prototype.__proto__ = Uint8Array.prototype
+  Buffer.__proto__ = Uint8Array
+
+  // Fix subarray() in ES2016. See: https://github.com/feross/buffer/pull/97
+  if (typeof Symbol !== 'undefined' && Symbol.species &&
+      Buffer[Symbol.species] === Buffer) {
+    Object.defineProperty(Buffer, Symbol.species, {
+      value: null,
+      configurable: true,
+      enumerable: false,
+      writable: false
+    })
+  }
 }
 
 function checked (length) {
@@ -47,19 +68,38 @@ function isnan (val) {
   return val !== val // eslint-disable-line no-self-compare
 }
 
-function createBuffer (length) {
-  var buf = new Uint8Array(length)
-  buf.__proto__ = Buffer.prototype
+function createBuffer (that, length) {
+  var buf
+  if (Buffer.TYPED_ARRAY_SUPPORT) {
+    buf = new Uint8Array(length)
+    buf.__proto__ = Buffer.prototype
+  } else {
+    // Fallback: Return an object instance of the Buffer class
+    buf = that
+    if (buf === null) {
+      buf = new Buffer(length)
+    }
+    buf.length = length
+  }
+
   return buf
 }
 
-function allocUnsafe (size) {
-  return createBuffer(size < 0 ? 0 : checked(size) | 0)
+function allocUnsafe (that, size) {
+  var buf = createBuffer(that, size < 0 ? 0 : checked(size) | 0)
+
+  if (!Buffer.TYPED_ARRAY_SUPPORT) {
+    for (var i = 0; i < size; ++i) {
+      buf[i] = 0
+    }
+  }
+
+  return buf
 }
 
-function fromString (string) {
+function fromString (that, string) {
   var length = byteLength(string) | 0
-  var buf = createBuffer(length)
+  var buf = createBuffer(that, length)
 
   var actual = buf.write(string)
 
@@ -73,16 +113,16 @@ function fromString (string) {
   return buf
 }
 
-function fromArrayLike (array) {
+function fromArrayLike (that, array) {
   var length = array.length < 0 ? 0 : checked(array.length) | 0
-  var buf = createBuffer(length)
+  var buf = createBuffer(that, length)
   for (var i = 0; i < length; i += 1) {
     buf[i] = array[i] & 255
   }
   return buf
 }
 
-function fromArrayBuffer (array, byteOffset, length) {
+function fromArrayBuffer (that, array, byteOffset, length) {
   if (byteOffset < 0 || array.byteLength < byteOffset) {
     throw new RangeError('\'offset\' is out of bounds')
   }
@@ -100,15 +140,21 @@ function fromArrayBuffer (array, byteOffset, length) {
     buf = new Uint8Array(array, byteOffset, length)
   }
 
-  // Return an augmented `Uint8Array` instance
-  buf.__proto__ = Buffer.prototype
+  if (Buffer.TYPED_ARRAY_SUPPORT) {
+    // Return an augmented `Uint8Array` instance, for best performance
+    buf.__proto__ = Buffer.prototype
+  } else {
+    // Fallback: Return an object instance of the Buffer class
+    buf = fromArrayLike(that, buf)
+  }
+
   return buf
 }
 
-function fromObject (obj) {
+function fromObject (that, obj) {
   if (Buffer.isBuffer(obj)) {
     var len = checked(obj.length) | 0
-    var buf = createBuffer(len)
+    var buf = createBuffer(that, len)
 
     if (buf.length === 0) {
       return buf
@@ -122,13 +168,13 @@ function fromObject (obj) {
     if ((typeof ArrayBuffer !== 'undefined' &&
         obj.buffer instanceof ArrayBuffer) || 'length' in obj) {
       if (typeof obj.length !== 'number' || isnan(obj.length)) {
-        return createBuffer(0)
+        return createBuffer(that, 0)
       }
-      return fromArrayLike(obj)
+      return fromArrayLike(that, obj)
     }
 
     if (obj.type === 'Buffer' && Array.isArray(obj.data)) {
-      return fromArrayLike(obj.data)
+      return fromArrayLike(that, obj.data)
     }
   }
 
@@ -245,20 +291,20 @@ function utf8Write (buf, string, offset, length) {
   return blitBuffer(utf8ToBytes(string, buf.length - offset), buf, offset, length)
 }
 
-function from (value, offset, length) {
+function from (that, value, offset, length) {
   if (typeof value === 'number') {
     throw new TypeError('"value" argument must not be a number')
   }
 
   if (typeof ArrayBuffer !== 'undefined' && value instanceof ArrayBuffer) {
-    return fromArrayBuffer(value, offset, length)
+    return fromArrayBuffer(that, value, offset, length)
   }
 
   if (typeof value === 'string') {
-    return fromString(value, offset)
+    return fromString(that, value, offset)
   }
 
-  return fromObject(value)
+  return fromObject(that, value)
 }
 
 Buffer.prototype.write = function write (string, offset, length) {
@@ -311,9 +357,19 @@ Buffer.prototype.slice = function slice (start, end) {
 
   if (end < start) end = start
 
-  var newBuf = this.subarray(start, end)
-  // Return an augmented `Uint8Array` instance
-  newBuf.__proto__ = Buffer.prototype
+  var newBuf
+  if (Buffer.TYPED_ARRAY_SUPPORT) {
+    newBuf = this.subarray(start, end)
+    // Return an augmented `Uint8Array` instance
+    newBuf.__proto__ = Buffer.prototype
+  } else {
+    var sliceLen = end - start
+    newBuf = new Buffer(sliceLen, undefined)
+    for (var i = 0; i < sliceLen; ++i) {
+      newBuf[i] = this[i + start]
+    }
+  }
+
   return newBuf
 }
 
@@ -349,7 +405,7 @@ Buffer.prototype.copy = function copy (target, targetStart, start, end) {
     for (i = len - 1; i >= 0; --i) {
       target[i + targetStart] = this[i + start]
     }
-  } else if (len < 1000) {
+  } else if (len < 1000 || !Buffer.TYPED_ARRAY_SUPPORT) {
     // ascending copy from start
     for (i = 0; i < len; ++i) {
       target[i + targetStart] = this[i + start]
@@ -433,7 +489,7 @@ Buffer.concat = function concat (list, length) {
     }
   }
 
-  var buffer = allocUnsafe(length)
+  var buffer = allocUnsafe(null, length)
   var pos = 0
   for (i = 0; i < list.length; ++i) {
     var buf = list[i]


### PR DESCRIPTION
This should let `node-qrcode` to work with browsers that don't support instance augmentation through `__proto__`.

(A polyfill for typedarray is still needed if not implemented by the browser.)

Should fix #91.