### PR TITLE
Build final kanji regex at runtime

### DIFF
--- a/lib/core/regex.js
+++ b/lib/core/regex.js
@@ -1,9 +1,11 @@
 var numeric = '[0-9]+'
 var alphanumeric = '[A-Z $%*+-./:]+'
-var kanji = '(?:[\u3000-\u303F]|[\u3040-\u309F]|[\u30A0-\u30FF]|' +
-  '[\uFF00-\uFFEF]|[\u4E00-\u9FAF]|[\u2605-\u2606]|[\u2190-\u2195]|\u203B|' +
-  '[\u2010\u2015\u2018\u2019\u2025\u2026\u201C\u201D\u2225\u2260]|' +
-  '[\u0391-\u0451]|[\u00A7\u00A8\u00B1\u00B4\u00D7\u00F7])+'
+var kanji = '(?:[u3000-u303F]|[u3040-u309F]|[u30A0-u30FF]|' +
+  '[uFF00-uFFEF]|[u4E00-u9FAF]|[u2605-u2606]|[u2190-u2195]|u203B|' +
+  '[u2010u2015u2018u2019u2025u2026u201Cu201Du2225u2260]|' +
+  '[u0391-u0451]|[u00A7u00A8u00B1u00B4u00D7u00F7])+'
+kanji = kanji.replace(/u/g, '\\u')
+
 var byte = '(?:(?![A-Z0-9 $%*+-./:]|' + kanji + ').)+'
 
 exports.KANJI = new RegExp(kanji, 'g')


### PR DESCRIPTION
As pointed in #94, an encoding different than UTF-8 may cause an invalid regular expression if unicode codes are converted to characters by some preprocessor (like uglifyJS).

This PR fixes the issue by building the final regex at runtime.