### PR TITLE
Fix wrongly handled input

### DIFF
--- a/bin/qrcode
+++ b/bin/qrcode
@@ -124,7 +124,6 @@ if (process.stdin.isTTY) {
   })
 
   process.stdin.on('end', function () {
-    text = text.replace(/\n$/, '')
     processInputs(text, argv)
   })
 }


### PR DESCRIPTION
Don't remove the `\n` at the end of the piped input.