### PR TITLE
Add support for Promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,31 @@ QRCode.toDataURL('I am a pony!', function (err, url) {
 })
 ```
 
+### ES6/ES7
+Promises and Async/Await can be used in place of callback function.
+
+```javascript
+import QRCode from 'qrcode'
+
+// With promises
+QRCode.toDataURL('I am a pony!')
+  .then(url => {
+    console.log(url)
+  })
+  .catch(err => {
+    console.error(err)
+  })
+
+// With async/await
+const generateQR = async text => {
+  try {
+    console.log(await QRCode.toDataURL(text))
+  } catch (err) {
+    console.error(err)
+  }
+}
+```
+
 ## Error correction level
 Error correction capability allows to successfully scan a QR Code even if the symbol is dirty or damaged.
 Four levels are available to choose according to the operating environment.
@@ -322,8 +347,8 @@ Type: `Object`
 
 <br>
 
-#### `toCanvas(canvasElement, text, [options], cb(error))`
-#### `toCanvas(text, [options], cb(error, canvas))`
+#### `toCanvas(canvasElement, text, [options], [cb(error)])`
+#### `toCanvas(text, [options], [cb(error, canvas)])`
 Draws qr code symbol to canvas.<br>
 If `canvasElement` is omitted a new canvas is returned.
 
@@ -357,8 +382,8 @@ QRCode.toCanvas('text', { errorCorrectionLevel: 'H' }, function (err, canvas) {
 
 <br>
 
-#### `toDataURL(text, [options], cb(error, url))`
-#### `toDataURL(canvasElement, text, [options], cb(error, url))`
+#### `toDataURL(text, [options], [cb(error, url)])`
+#### `toDataURL(canvasElement, text, [options], [cb(error, url)])`
 Returns a Data URI containing a representation of the QR Code image.<br>
 If provided, `canvasElement` will be used as canvas to generate the data URI.
 
@@ -413,7 +438,7 @@ QRCode.toDataURL('text', opts, function (err, url) {
 ```
 <br>
 
-#### `toString(text, [options], cb(error, string))`
+#### `toString(text, [options], [cb(error, string)])`
 
 Returns a string representation of the QR Code.<br>
 Currently only works for SVG.
@@ -455,7 +480,7 @@ See [create](#createtext-options).
 
 <br>
 
-#### `toCanvas(canvas, text, [options], cb(error))`
+#### `toCanvas(canvas, text, [options], [cb(error)])`
 Draws qr code symbol to [node canvas](https://github.com/Automattic/node-canvas).
 
 ##### `text`
@@ -473,7 +498,7 @@ Callback function called on finish.
 
 <br>
 
-#### `toDataURL(text, [options], cb(error, url))`
+#### `toDataURL(text, [options], [cb(error, url)])`
 Returns a Data URI containing a representation of the QR Code image.<br>
 Only works with `image/png` type for now.
 
@@ -492,7 +517,7 @@ Callback function called on finish.
 
 <br>
 
-#### `toString(text, [options], cb(error, string))`
+#### `toString(text, [options], [cb(error, string)])`
 Returns a string representation of the QR Code.<br>
 If choosen output format is `svg` it will returns a string containing xml code.
 
@@ -526,7 +551,7 @@ QRCode.toString('http://www.google.com', function (err, string) {
 
 <br>
 
-#### `toFile(path, text, [options], cb(error))`
+#### `toFile(path, text, [options], [cb(error)])`
 Saves QR Code to image file.<br>
 If `options.type` is not specified, the format will be guessed from file extension.<br>
 Recognized extensions are `png`, `svg`, `txt`.

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,31 +1,59 @@
+var canPromise = require('can-promise')
 var QRCode = require('./core/qrcode')
 var CanvasRenderer = require('./renderer/canvas')
 var SvgRenderer = require('./renderer/svg-tag.js')
 
 function renderCanvas (renderFunc, canvas, text, opts, cb) {
-  var argsNum = arguments.length - 1
-  if (argsNum < 2) {
-    throw new Error('Too few arguments provided')
+  var args = [].slice.call(arguments, 1)
+  var argsNum = args.length
+  var isLastArgCb = typeof args[argsNum - 1] === 'function'
+
+  if (!isLastArgCb && !canPromise()) {
+    throw new Error('Callback required as last argument')
   }
 
-  if (argsNum === 2) {
-    cb = text
-    text = canvas
-    canvas = opts = undefined
-  } else if (argsNum === 3) {
-    if (canvas.getContext && typeof cb === 'undefined') {
-      cb = opts
-      opts = undefined
-    } else {
-      cb = opts
+  if (isLastArgCb) {
+    if (argsNum < 2) {
+      throw new Error('Too few arguments provided')
+    }
+
+    if (argsNum === 2) {
+      cb = text
+      text = canvas
+      canvas = opts = undefined
+    } else if (argsNum === 3) {
+      if (canvas.getContext && typeof cb === 'undefined') {
+        cb = opts
+        opts = undefined
+      } else {
+        cb = opts
+        opts = text
+        text = canvas
+        canvas = undefined
+      }
+    }
+  } else {
+    if (argsNum < 1) {
+      throw new Error('Too few arguments provided')
+    }
+
+    if (argsNum === 1) {
+      text = canvas
+      canvas = opts = undefined
+    } else if (argsNum === 2 && !canvas.getContext) {
       opts = text
       text = canvas
       canvas = undefined
     }
-  }
 
-  if (typeof cb !== 'function') {
-    throw new Error('Callback required as last argument')
+    return new Promise(function (resolve, reject) {
+      try {
+        var data = QRCode.create(text, opts)
+        resolve(renderFunc(data, canvas, opts))
+      } catch (e) {
+        reject(e)
+      }
+    })
   }
 
   try {

--- a/lib/renderer/svg-tag.js
+++ b/lib/renderer/svg-tag.js
@@ -52,7 +52,7 @@ function qrToPath (data, size, margin) {
   return path
 }
 
-exports.render = function render (qrData, options) {
+exports.render = function render (qrData, options, cb) {
   var opts = Utils.getOptions(options)
   var size = qrData.modules.size
   var data = qrData.modules.data
@@ -71,5 +71,11 @@ exports.render = function render (qrData, options) {
 
   var width = !opts.width ? '' : 'width="' + opts.width + '" height="' + opts.width + '" '
 
-  return '<svg xmlns="http://www.w3.org/2000/svg" ' + width + viewBox + '>' + bg + path + '</svg>'
+  var svgTag = '<svg xmlns="http://www.w3.org/2000/svg" ' + width + viewBox + '>' + bg + path + '</svg>'
+
+  if (typeof cb === 'function') {
+    cb(null, svgTag)
+  }
+
+  return svgTag
 }

--- a/lib/renderer/terminal.js
+++ b/lib/renderer/terminal.js
@@ -1,6 +1,6 @@
 // var Utils = require('./utils')
 
-exports.render = function (qrData, options) {
+exports.render = function (qrData, options, cb) {
   var size = qrData.modules.size
   var data = qrData.modules.data
 
@@ -28,6 +28,11 @@ exports.render = function (qrData, options) {
   }
 
   output += hMargin + '\n'
+
+  if (typeof cb === 'function') {
+    cb(null, output)
+  }
+
   return output
 }
 /*

--- a/lib/renderer/utf8.js
+++ b/lib/renderer/utf8.js
@@ -14,7 +14,7 @@ function getBlockChar (top, bottom) {
   return BLOCK_CHAR.WW
 }
 
-exports.render = function (qrData, options) {
+exports.render = function (qrData, options, cb) {
   var size = qrData.modules.size
   var data = qrData.modules.data
 
@@ -40,6 +40,11 @@ exports.render = function (qrData, options) {
   }
 
   output += hMargin.slice(0, -1)
+
+  if (typeof cb === 'function') {
+    cb(null, output)
+  }
+
   return output
 }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,3 +1,4 @@
+var canPromise = require('can-promise')
 var QRCode = require('./core/qrcode')
 var PngRenderer = require('./renderer/png')
 var Utf8Renderer = require('./renderer/utf8')
@@ -15,7 +16,12 @@ function checkParams (text, opts, cb) {
   }
 
   if (typeof cb !== 'function') {
-    throw new Error('Callback required as last argument')
+    if (!canPromise()) {
+      throw new Error('Callback required as last argument')
+    } else {
+      opts = cb || {}
+      cb = null
+    }
   }
 
   return {
@@ -59,6 +65,19 @@ function getStringRendererFromType (type) {
 }
 
 function render (renderFunc, text, params) {
+  if (!params.cb) {
+    return new Promise(function (resolve, reject) {
+      try {
+        var data = QRCode.create(text, params.opts)
+        return renderFunc(data, params.opts, function (err, data) {
+          return err ? reject(err) : resolve(data)
+        })
+      } catch (e) {
+        reject(e)
+      }
+    })
+  }
+
   try {
     var data = QRCode.create(text, params.opts)
     return renderFunc(data, params.opts, params.cb)
@@ -74,19 +93,21 @@ exports.toCanvas = require('./browser').toCanvas
 exports.toString = function toString (text, opts, cb) {
   var params = checkParams(text, opts, cb)
   var renderer = getStringRendererFromType(params.opts.type)
-  var string = render(renderer.render, text, params)
-  if (string) params.cb(null, string)
+  return render(renderer.render, text, params)
 }
 
 exports.toDataURL = function toDataURL (text, opts, cb) {
   var params = checkParams(text, opts, cb)
   var renderer = getRendererFromType(params.opts.type)
-
-  render(renderer.renderToDataURL, text, params)
+  return render(renderer.renderToDataURL, text, params)
 }
 
 exports.toFile = function toFile (path, text, opts, cb) {
-  if (arguments.length < 3) {
+  if (typeof path !== 'string' || typeof text !== 'string') {
+    throw new Error('Invalid argument')
+  }
+
+  if ((arguments.length < 3) && !canPromise()) {
     throw new Error('Too few arguments provided')
   }
 
@@ -95,7 +116,7 @@ exports.toFile = function toFile (path, text, opts, cb) {
   var renderer = getRendererFromType(type)
   var renderToFile = renderer.renderToFile.bind(null, path)
 
-  render(renderToFile, text, params)
+  return render(renderToFile, text, params)
 }
 
 exports.toFileStream = function toFileStream (stream, text, opts) {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "qrcode": "./bin/qrcode"
   },
   "dependencies": {
+    "can-promise": "^0.0.1",
     "dijkstrajs": "^1.0.1",
     "isarray": "^2.0.1",
     "pngjs": "^3.3.0",

--- a/test/e2e/toCanvas.test.js
+++ b/test/e2e/toCanvas.test.js
@@ -1,6 +1,38 @@
 var test = require('tap').test
 var Canvas = require('canvas')
 var QRCode = require('lib')
+var Helpers = require('test/helpers')
+
+test('toCanvas - no promise available', function (t) {
+  Helpers.removeNativePromise()
+
+  // Mock document object
+  global.document = {
+    createElement: function (el) {
+      if (el === 'canvas') {
+        return new Canvas(200, 200)
+      }
+    }
+  }
+  var canvasEl = new Canvas(200, 200)
+
+  t.throw(function () { QRCode.toCanvas() },
+    'Should throw if no arguments are provided')
+
+  t.throw(function () { QRCode.toCanvas('some text') },
+    'Should throw if a callback is not provided')
+
+  t.throw(function () { QRCode.toCanvas(canvasEl, 'some text') },
+    'Should throw if a callback is not provided')
+
+  t.throw(function () { QRCode.toCanvas(canvasEl, 'some text', {}) },
+    'Should throw if callback is not a function')
+
+  t.end()
+
+  global.document = undefined
+  Helpers.restoreNativePromise()
+})
 
 test('toCanvas', function (t) {
   // Mock document object
@@ -17,12 +49,6 @@ test('toCanvas', function (t) {
   t.throw(function () { QRCode.toCanvas() },
     'Should throw if no arguments are provided')
 
-  t.throw(function () { QRCode.toCanvas('some text') },
-    'Should throw if a callback is not provided')
-
-  t.throw(function () { QRCode.toCanvas('some text', {}) },
-    'Should throw if callback is not a function')
-
   QRCode.toCanvas('some text', function (err, canvasEl) {
     t.ok(!err, 'There should be no error')
     t.ok(canvasEl instanceof Canvas,
@@ -37,6 +63,18 @@ test('toCanvas', function (t) {
       'Should return a new canvas object')
   })
 
+  QRCode.toCanvas('some text').then(function (canvasEl) {
+    t.ok(canvasEl instanceof Canvas,
+      'Should return a new canvas object (promise)')
+  })
+
+  QRCode.toCanvas('some text', {
+    errorCorrectionLevel: 'H'
+  }).then(function (canvasEl) {
+    t.ok(canvasEl instanceof Canvas,
+      'Should return a new canvas object (promise)')
+  })
+
   global.document = undefined
 })
 
@@ -44,12 +82,6 @@ test('toCanvas with specified canvas element', function (t) {
   var canvasEl = new Canvas(200, 200)
 
   t.plan(6)
-
-  t.throw(function () { QRCode.toCanvas(canvasEl, 'some text') },
-    'Should throw if a callback is not provided')
-
-  t.throw(function () { QRCode.toCanvas(canvasEl, 'some text', {}) },
-    'Should throw if callback is not a function')
 
   QRCode.toCanvas(canvasEl, 'some text', function (err, canvasEl) {
     t.ok(!err, 'There should be no error')
@@ -63,5 +95,17 @@ test('toCanvas with specified canvas element', function (t) {
     t.ok(!err, 'There should be no error')
     t.ok(canvasEl instanceof Canvas,
       'Should return a new canvas object')
+  })
+
+  QRCode.toCanvas(canvasEl, 'some text').then(function (canvasEl) {
+    t.ok(canvasEl instanceof Canvas,
+      'Should return a new canvas object (promise)')
+  })
+
+  QRCode.toCanvas(canvasEl, 'some text', {
+    errorCorrectionLevel: 'H'
+  }).then(function (canvasEl) {
+    t.ok(canvasEl instanceof Canvas,
+      'Should return a new canvas object (promise)')
   })
 })

--- a/test/e2e/toString.test.js
+++ b/test/e2e/toString.test.js
@@ -3,16 +3,81 @@ var fs = require('fs')
 var path = require('path')
 var QRCode = require('lib')
 var browser = require('lib/browser')
+var Helpers = require('test/helpers')
 
-test('toString svg', function (t) {
-  var file = path.join(__dirname, '/svgtag.expected.out')
-  t.plan(6)
+test('toString - no promise available', function (t) {
+  Helpers.removeNativePromise()
 
   t.throw(function () { QRCode.toString() },
     'Should throw if text is not provided')
 
   t.throw(function () { QRCode.toString('some text') },
     'Should throw if a callback is not provided')
+
+  t.throw(function () { QRCode.toString('some text', {}) },
+    'Should throw if a callback is not a function')
+
+  t.throw(function () { QRCode.toString() },
+    'Should throw if text is not provided (browser)')
+
+  t.throw(function () { browser.toString('some text') },
+    'Should throw if a callback is not provided (browser)')
+
+  t.throw(function () { browser.toString('some text', {}) },
+    'Should throw if a callback is not a function (browser)')
+
+  t.end()
+
+  Helpers.restoreNativePromise()
+})
+
+test('toString', function (t) {
+  t.plan(5)
+
+  t.throw(function () { QRCode.toString() },
+    'Should throw if text is not provided')
+
+  QRCode.toString('some text', function (err, str) {
+    t.ok(!err, 'There should be no error')
+    t.equals(typeof str, 'string',
+      'Should return a string')
+  })
+
+  t.equals(typeof QRCode.toString('some text').then, 'function',
+    'Should return a promise')
+
+  QRCode.toString('some text', { errorCorrectionLevel: 'L' })
+    .then(function (str) {
+      t.equals(typeof str, 'string',
+        'Should return a string')
+    })
+})
+
+test('toString (browser)', function (t) {
+  t.plan(5)
+
+  t.throw(function () { browser.toString() },
+    'Should throw if text is not provided')
+
+  browser.toString('some text', function (err, str) {
+    t.ok(!err, 'There should be no error (browser)')
+    t.equals(typeof str, 'string',
+      'Should return a string (browser)')
+  })
+
+  t.equals(typeof browser.toString('some text').then, 'function',
+    'Should return a promise')
+
+  browser.toString('some text', { errorCorrectionLevel: 'L' })
+    .then(function (str) {
+      t.equals(typeof str, 'string',
+        'Should return a string')
+    })
+})
+
+test('toString svg', function (t) {
+  var file = path.join(__dirname, '/svgtag.expected.out')
+  t.plan(6)
 
   QRCode.toString('http://www.google.com', {
     version: 1, // force version=1 to trigger an error
@@ -34,10 +99,32 @@ test('toString svg', function (t) {
       t.equal(code, expectedSvg, 'should output a valid svg')
     })
   })
+
+  QRCode.toString('http://www.google.com', {
+    version: 1, // force version=1 to trigger an error
+    errorCorrectionLevel: 'H',
+    type: 'svg'
+  }).catch(function (err) {
+    t.ok(err, 'there should be an error (promise)')
+  })
+
+  fs.readFile(file, 'utf8', function (err, expectedSvg) {
+    if (err) throw err
+
+    QRCode.toString('http://www.google.com', {
+      errorCorrectionLevel: 'H',
+      type: 'svg'
+    }).then(function (code) {
+      t.equal(code, expectedSvg, 'should output a valid svg (promise)')
+    })
+  })
 })
 
 test('toString browser svg', function (t) {
   var file = path.join(__dirname, '/svgtag.expected.out')
+
+  t.plan(3)
+
   fs.readFile(file, 'utf8', function (err, expectedSvg) {
     if (err) throw err
 
@@ -47,7 +134,13 @@ test('toString browser svg', function (t) {
     }, function (err, code) {
       t.ok(!err, 'There should be no error')
       t.equal(code, expectedSvg, 'should output a valid svg')
-      t.end()
+    })
+
+    browser.toString('http://www.google.com', {
+      errorCorrectionLevel: 'H',
+      type: 'svg'
+    }).then(function (code) {
+      t.equal(code, expectedSvg, 'should output a valid svg (promise)')
     })
   })
 })
@@ -72,13 +165,7 @@ test('toString utf8', function (t) {
     '                                 ',
     '                                 '].join('\n')
 
-  t.plan(8)
-
-  t.throw(function () { QRCode.toString() },
-    'Should throw if text is not provided')
-
-  t.throw(function () { QRCode.toString('some text') },
-    'Should throw if a callback is not provided')
+  t.plan(9)
 
   QRCode.toString('http://www.google.com', {
     version: 1, // force version=1 to trigger an error
@@ -102,18 +189,32 @@ test('toString utf8', function (t) {
     t.equal(code, expectedUtf8,
       'Should output a valid symbol with default options')
   })
+
+  QRCode.toString('http://www.google.com', {
+    version: 1, // force version=1 to trigger an error
+    errorCorrectionLevel: 'H',
+    type: 'utf8'
+  }).catch(function (err) {
+    t.ok(err, 'there should be an error (promise)')
+  })
+
+  QRCode.toString('http://www.google.com', {
+    errorCorrectionLevel: 'M',
+    type: 'utf8'
+  }).then(function (code) {
+    t.equal(code, expectedUtf8, 'should output a valid symbol (promise)')
+  })
+
+  QRCode.toString('http://www.google.com').then(function (code) {
+    t.equal(code, expectedUtf8,
+      'Should output a valid symbol with default options (promise)')
+  })
 })
 
 test('toString terminal', function (t) {
   var expectedTerminal = fs.readFileSync(path.join(__dirname, '/terminal.expected.out')) + ''
 
-  t.plan(4)
-
-  t.throw(function () { QRCode.toString() },
-    'Should throw if text is not provided')
-
-  t.throw(function () { QRCode.toString('some text') },
-    'Should throw if a callback is not provided')
+  t.plan(3)
 
   QRCode.toString('http://www.google.com', {
     errorCorrectionLevel: 'M',
@@ -121,5 +222,12 @@ test('toString terminal', function (t) {
   }, function (err, code) {
     t.ok(!err, 'There should be no error')
     t.equal(code + '\n', expectedTerminal, 'should output a valid symbol')
+  })
+
+  QRCode.toString('http://www.google.com', {
+    errorCorrectionLevel: 'M',
+    type: 'terminal'
+  }).then(function (code) {
+    t.equal(code + '\n', expectedTerminal, 'should output a valid symbol (promise)')
   })
 })

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,13 @@
+var nativePromise = global.Promise
+
+exports.removeNativePromise = function () {
+  if (global.Promise) {
+    delete global.Promise
+  }
+}
+
+exports.restoreNativePromise = function () {
+  if (!global.Promise) {
+    global.Promise = nativePromise
+  }
+}


### PR DESCRIPTION
Adds support for Promises along with the current callback interface.
If Promises are not available an error will enforce the use of a cb function.

All the following methods are valid and can be used interchangeably:
```javascript
// With callback
QRCode.toDataURL('I am a pony!', function (err, url) {
  if (err) console.error(err)
  console.log(url)
})
```
```javascript
// With promises
QRCode.toDataURL('I am a pony!')
  .then(url => {
    console.log(url)
  })
  .catch(err => {
    console.error(err)
  })
```
```javascript
// With async/await
const generateQR = async text => {
  try {
    console.log(await QRCode.toDataURL(text))
  } catch (err) {
    console.error(err)
  }
}
```

Closes #107