### PR TITLE
Fix passing manual segments list to QRCode.toFile

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -103,7 +103,7 @@ exports.toDataURL = function toDataURL (text, opts, cb) {
 }
 
 exports.toFile = function toFile (path, text, opts, cb) {
-  if (typeof path !== 'string' || typeof text !== 'string') {
+  if (typeof path !== 'string' || !(typeof text === 'string' || typeof text === 'object')) {
     throw new Error('Invalid argument')
   }
 

--- a/test/e2e/toFile.test.js
+++ b/test/e2e/toFile.test.js
@@ -226,3 +226,45 @@ test('toFile utf8', function (t) {
       })
     })
 })
+
+test('toFile manual segments', function (t) {
+  var fileName = path.join(tmpDir(), 'qrimage.txt')
+  var segs = [
+    { data: 'ABCDEFG', mode: 'alphanumeric' },
+    { data: '0123456', mode: 'numeric' }
+  ]
+  var expectedOutput = [
+    '                             ',
+    '                             ',
+    '    █▀▀▀▀▀█ ██▀██ █▀▀▀▀▀█    ',
+    '    █ ███ █  █▀█▄ █ ███ █    ',
+    '    █ ▀▀▀ █ █ ▄ ▀ █ ▀▀▀ █    ',
+    '    ▀▀▀▀▀▀▀ █▄█▄▀ ▀▀▀▀▀▀▀    ',
+    '    ▀██ ▄▀▀▄█▀▀▀▀██▀▀▄ █▀    ',
+    '     ▀█▀▀█▀█▄ ▄ ▄█▀▀▀█▀      ',
+    '    ▀ ▀▀▀ ▀ ▄▀ ▄ ▄▀▄  ▀▄     ',
+    '    █▀▀▀▀▀█ ▄  █▀█ ▀▀▀▄█▄    ',
+    '    █ ███ █  █▀▀▀ ██▀▀ ▀▀    ',
+    '    █ ▀▀▀ █ ██  ▄▀▀▀▀▄▀▀█    ',
+    '    ▀▀▀▀▀▀▀ ▀    ▀▀▀▀ ▀▀▀    ',
+    '                             ',
+    '                             '].join('\n')
+  t.plan(3)
+
+  QRCode.toFile(fileName, segs, {
+    errorCorrectionLevel: 'L'
+  }, function (err) {
+    t.ok(!err, 'There should be no errors if text is not string')
+
+    fs.stat(fileName, function (err) {
+      t.ok(!err,
+        'Should save file with correct file name')
+    })
+
+    fs.readFile(fileName, 'utf8', function (err, content) {
+      if (err) throw err
+      t.equal(content, expectedOutput,
+        'Should write correct content')
+    })
+  })
+})


### PR DESCRIPTION
`QRCode.toFile` should accept segments list as documented in Manual mode.