### PR TITLE
Bump canvas for Node.js 10.x compatability

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "browserify": "^14.1.0",
-    "canvas": "^1.6.4",
+    "canvas": "^1.6.11",
     "canvasutil": "*",
     "colors": "*",
     "express": "2.5.x",


### PR DESCRIPTION
When installing on Node.js 10.x the build stage will fail when installing `canvas` fixed in this [PR](https://github.com/Automattic/node-canvas/pull/1166)