### PR TITLE
Fix maskPattern 0 parameter

### DIFF
--- a/lib/core/mask-pattern.js
+++ b/lib/core/mask-pattern.js
@@ -31,7 +31,7 @@ var PenaltyScores = {
  * @return {Boolean}         true if valid, false otherwise
  */
 exports.isValid = function isValid (mask) {
-  return mask && mask !== '' && !isNaN(mask) && mask >= 0 && mask <= 7
+  return mask != null && mask !== '' && !isNaN(mask) && mask >= 0 && mask <= 7
 }
 
 /**

--- a/lib/core/qrcode.js
+++ b/lib/core/qrcode.js
@@ -445,7 +445,7 @@ function createSymbol (data, version, errorCorrectionLevel, maskPattern) {
   // Add data codewords
   setupData(modules, dataBits)
 
-  if (!maskPattern) {
+  if (isNaN(maskPattern)) {
     // Find best mask pattern
     maskPattern = MaskPattern.getBestMask(modules,
       setupFormatInfo.bind(null, modules, errorCorrectionLevel))


### PR DESCRIPTION
When providing the option maskPattern it doesn't correctly handle mask
pattern 0. The checks failed to account for the fact that 0 is a falsy
value.