### PR TITLE
ensure to include CR/LF in BYTE segments

### DIFF
--- a/lib/core/regex.js
+++ b/lib/core/regex.js
@@ -10,7 +10,7 @@ var byte = '(?:(?![A-Z0-9 $%*+\\-./:]|' + kanji + ').)+'
 
 exports.KANJI = new RegExp(kanji, 'g')
 exports.BYTE_KANJI = new RegExp('[^A-Z0-9 $%*+\\-./:]+', 'g')
-exports.BYTE = new RegExp(byte, 'g')
+exports.BYTE = new RegExp(byte, 'gs')
 exports.NUMERIC = new RegExp(numeric, 'g')
 exports.ALPHANUMERIC = new RegExp(alphanumeric, 'g')
 

--- a/lib/core/regex.js
+++ b/lib/core/regex.js
@@ -6,11 +6,11 @@ var kanji = '(?:[u3000-u303F]|[u3040-u309F]|[u30A0-u30FF]|' +
   '[u0391-u0451]|[u00A7u00A8u00B1u00B4u00D7u00F7])+'
 kanji = kanji.replace(/u/g, '\\u')
 
-var byte = '(?:(?![A-Z0-9 $%*+\\-./:]|' + kanji + ').)+'
+var byte = '(?:(?![A-Z0-9 $%*+\\-./:]|' + kanji + ')(?:.|[\r\n]))+'
 
 exports.KANJI = new RegExp(kanji, 'g')
 exports.BYTE_KANJI = new RegExp('[^A-Z0-9 $%*+\\-./:]+', 'g')
-exports.BYTE = new RegExp(byte, 'gs')
+exports.BYTE = new RegExp(byte, 'g')
 exports.NUMERIC = new RegExp(numeric, 'g')
 exports.ALPHANUMERIC = new RegExp(alphanumeric, 'g')
 

--- a/test/unit/core/segments.test.js
+++ b/test/unit/core/segments.test.js
@@ -126,6 +126,12 @@ var testData = [
       {data: 'Aa', mode: Mode.BYTE},
       {data: '12345A', mode: Mode.ALPHANUMERIC}
     ]
+  },
+  {
+    input: 'ABC\nDEF',
+    result: [
+      {data: 'ABC\nDEF', mode: Mode.BYTE}
+    ]
   }
 ]
 
@@ -142,6 +148,13 @@ var kanjiTestData = [
     input: '皿a晒三',
     result: [
       {data: '皿a', mode: Mode.BYTE},
+      {data: '晒三', mode: Mode.KANJI}
+    ]
+  },
+  {
+    input: '皿a\n晒三',
+    result: [
+      {data: '皿a\n', mode: Mode.BYTE},
       {data: '晒三', mode: Mode.KANJI}
     ]
   }


### PR DESCRIPTION
When kanji mode is enabled, CR/LF will be silently dropped from the input string
because regexp `/./` doesn't include CR/LF. It should be `/(?:.|[\r\n])/`.

```
$ node
> /./.test("\n")
false
> /(?:.|[\r\n])/.test("\n")
true
```

UPDATE: originally written `/./s` is ES2018 feature. Use explicit character instead.