### PR TITLE
remove can-promise package which is no longer used

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "qrcode": "./bin/qrcode"
   },
   "dependencies": {
-    "can-promise": "0.0.1",
     "dijkstrajs": "^1.0.1",
     "isarray": "^2.0.1",
     "pngjs": "^3.3.0",


### PR DESCRIPTION
`can-promise` seems no longer used, but remains in package.json.