### PR TITLE
docs: remove note about webp support

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,6 @@ Text to encode or a list of objects describing segments.
 
   Data URI format.<br>
   Possible values are: `image/png`, `image/jpeg`, `image/webp`.<br>
-  **Note: `image/webp` only works in Chrome browser.**
 
 - ###### `rendererOpts.quality`
   Type: `Number`<br>


### PR DESCRIPTION
The note was outdated, Chrome is not the only browser that
supports WebP: https://caniuse.com/#search=webp