### PR TITLE
Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,21 +49,22 @@ npm install -g qrcode
 Usage: qrcode [options] <input string>
 
 QR Code options:
-  -v, --version  QR Code symbol version (1 - 40)
-  -e, --error    Error correction level            [choices: "L", "M", "Q", "H"]
-  -m, --mask     Mask pattern (0 - 7)
+  -v, --qversion  QR Code symbol version (1 - 40)                       [number]
+  -e, --error     Error correction level           [choices: "L", "M", "Q", "H"]
+  -m, --mask      Mask pattern (0 - 7)                                  [number]
 
 Renderer options:
   -t, --type        Output type                  [choices: "png", "svg", "utf8"]
-  -w, --width       Image width (px)
-  -s, --scale       Scale factor
-  -q, --qzone       Quiet zone size
+  -w, --width       Image width (px)                                    [number]
+  -s, --scale       Scale factor                                        [number]
+  -q, --qzone       Quiet zone size                                     [number]
   -l, --lightcolor  Light RGBA hex color
   -d, --darkcolor   Dark RGBA hex color
 
 Options:
   -o, --output  Output file
   -h, --help    Show help                                              [boolean]
+  --version     Show version number                                    [boolean]
 
 Examples:
   qrcode "some text"                    Draw in terminal window

--- a/bin/qrcode
+++ b/bin/qrcode
@@ -27,7 +27,7 @@ function print (text, options) {
 
 function parseOptions (args) {
   return {
-    version: args.version,
+    version: args.qversion,
     errorCorrectionLevel: args.error,
     type: args.type,
     maskPattern: args.mask,
@@ -57,7 +57,7 @@ function processInputs (text, opts) {
 var argv = yargs
   .detectLocale(false)
   .usage('Usage: $0 [options] <input string>')
-  .option('qv', {
+  .option('v', {
     alias: 'qversion',
     description: 'QR Code symbol version (1 - 40)',
     group: 'QR Code options:'
@@ -113,6 +113,7 @@ var argv = yargs
   })
   .help('h')
   .alias('h', 'help')
+  .version()
   .example('$0 "some text"', 'Draw in terminal window')
   .example('$0 -o out.png "some text"', 'Save as png image')
   .example('$0 -d F00 -o out.png "some text"', 'Use red as foreground color')

--- a/bin/qrcode
+++ b/bin/qrcode
@@ -60,7 +60,8 @@ var argv = yargs
   .option('v', {
     alias: 'qversion',
     description: 'QR Code symbol version (1 - 40)',
-    group: 'QR Code options:'
+    group: 'QR Code options:',
+    type: 'number'
   })
   .option('e', {
     alias: 'error',
@@ -71,7 +72,8 @@ var argv = yargs
   .option('m', {
     alias: 'mask',
     description: 'Mask pattern (0 - 7)',
-    group: 'QR Code options:'
+    group: 'QR Code options:',
+    type: 'number'
   })
   .option('t', {
     alias: 'type',
@@ -84,18 +86,21 @@ var argv = yargs
     alias: 'width',
     description: 'Image width (px)',
     conflicts: 'scale',
-    group: 'Renderer options:'
+    group: 'Renderer options:',
+    type: 'number'
   })
   .option('s', {
     alias: 'scale',
     description: 'Scale factor',
     conflicts: 'width',
-    group: 'Renderer options:'
+    group: 'Renderer options:',
+    type: 'number'
   })
   .option('q', {
     alias: 'qzone',
     description: 'Quiet zone size',
-    group: 'Renderer options:'
+    group: 'Renderer options:',
+    type: 'number'
   })
   .option('l', {
     alias: 'lightcolor',


### PR DESCRIPTION
Fixes #201.

Now is also consistent with readme docs.

All number args only accept integers now also :)

And `--version` still works fine.