### PR TITLE
Avoid using deprecated APIs on newer Node.js

### DIFF
--- a/lib/core/bit-matrix.js
+++ b/lib/core/bit-matrix.js
@@ -1,4 +1,4 @@
-var Buffer = require('../utils/buffer')
+var BufferUtil = require('../utils/buffer')
 
 /**
  * Helper class to handle QR Code symbol modules
@@ -11,10 +11,8 @@ function BitMatrix (size) {
   }
 
   this.size = size
-  this.data = new Buffer(size * size)
-  this.data.fill(0)
-  this.reservedBit = new Buffer(size * size)
-  this.reservedBit.fill(0)
+  this.data = BufferUtil.alloc(size * size)
+  this.reservedBit = BufferUtil.alloc(size * size)
 }
 
 /**

--- a/lib/core/byte-data.js
+++ b/lib/core/byte-data.js
@@ -1,9 +1,9 @@
-var Buffer = require('../utils/buffer')
+var BufferUtil = require('../utils/buffer')
 var Mode = require('./mode')
 
 function ByteData (data) {
   this.mode = Mode.BYTE
-  this.data = new Buffer(data)
+  this.data = BufferUtil.from(data)
 }
 
 ByteData.getBitsLength = function getBitsLength (length) {

--- a/lib/core/galois-field.js
+++ b/lib/core/galois-field.js
@@ -1,15 +1,7 @@
-var Buffer = require('../utils/buffer')
+var BufferUtil = require('../utils/buffer')
 
-var EXP_TABLE
-var LOG_TABLE
-
-if (Buffer.alloc) {
-  EXP_TABLE = Buffer.alloc(512)
-  LOG_TABLE = Buffer.alloc(256)
-} else {
-  EXP_TABLE = new Buffer(512)
-  LOG_TABLE = new Buffer(256)
-}
+var EXP_TABLE = BufferUtil.alloc(512)
+var LOG_TABLE = BufferUtil.alloc(256)
 /**
  * Precompute the log and anti-log tables for faster computation later
  *

--- a/lib/core/polynomial.js
+++ b/lib/core/polynomial.js
@@ -1,4 +1,4 @@
-var Buffer = require('../utils/buffer')
+var BufferUtil = require('../utils/buffer')
 var GF = require('./galois-field')
 
 /**
@@ -9,8 +9,7 @@ var GF = require('./galois-field')
  * @return {Buffer}    Product of p1 and p2
  */
 exports.mul = function mul (p1, p2) {
-  var coeff = new Buffer(p1.length + p2.length - 1)
-  coeff.fill(0)
+  var coeff = BufferUtil.alloc(p1.length + p2.length - 1)
 
   for (var i = 0; i < p1.length; i++) {
     for (var j = 0; j < p2.length; j++) {
@@ -29,7 +28,7 @@ exports.mul = function mul (p1, p2) {
  * @return {Buffer}          Remainder
  */
 exports.mod = function mod (divident, divisor) {
-  var result = new Buffer(divident)
+  var result = BufferUtil.from(divident)
 
   while ((result.length - divisor.length) >= 0) {
     var coeff = result[0]
@@ -55,7 +54,7 @@ exports.mod = function mod (divident, divisor) {
  * @return {Buffer}        Buffer containing polynomial coefficients
  */
 exports.generateECPolynomial = function generateECPolynomial (degree) {
-  var poly = new Buffer([1])
+  var poly = BufferUtil.from([1])
   for (var i = 0; i < degree; i++) {
     poly = exports.mul(poly, [1, GF.exp(i)])
   }

--- a/lib/core/qrcode.js
+++ b/lib/core/qrcode.js
@@ -1,4 +1,4 @@
-var Buffer = require('../utils/buffer')
+var BufferUtil = require('../utils/buffer')
 var Utils = require('./utils')
 var ECLevel = require('./error-correction-level')
 var BitBuffer = require('./bit-buffer')
@@ -327,7 +327,7 @@ function createCodewords (bitBuffer, version, errorCorrectionLevel) {
   var dcData = new Array(ecTotalBlocks)
   var ecData = new Array(ecTotalBlocks)
   var maxDataSize = 0
-  var buffer = new Buffer(bitBuffer.buffer)
+  var buffer = BufferUtil.from(bitBuffer.buffer)
 
   // Divide the buffer into the required number of blocks
   for (var b = 0; b < ecTotalBlocks; b++) {
@@ -345,7 +345,7 @@ function createCodewords (bitBuffer, version, errorCorrectionLevel) {
 
   // Create final data
   // Interleave the data and error correction codewords from each block
-  var data = new Buffer(totalCodewords)
+  var data = BufferUtil.alloc(totalCodewords)
   var index = 0
   var i, r
 

--- a/lib/core/reed-solomon-encoder.js
+++ b/lib/core/reed-solomon-encoder.js
@@ -1,4 +1,4 @@
-var Buffer = require('../utils/buffer')
+var BufferUtil = require('../utils/buffer')
 var Polynomial = require('./polynomial')
 
 function ReedSolomonEncoder (degree) {
@@ -33,8 +33,7 @@ ReedSolomonEncoder.prototype.encode = function encode (data) {
 
   // Calculate EC for this data block
   // extends data size to data+genPoly size
-  var pad = new Buffer(this.degree)
-  pad.fill(0)
+  var pad = BufferUtil.alloc(this.degree)
   var paddedData = Buffer.concat([data, pad], data.length + this.degree)
 
   // The error correction codewords are the remainder after dividing the data codewords
@@ -46,8 +45,7 @@ ReedSolomonEncoder.prototype.encode = function encode (data) {
   // pad with 0s to the left to reach the needed number of coefficients
   var start = this.degree - remainder.length
   if (start > 0) {
-    var buff = new Buffer(this.degree)
-    buff.fill(0)
+    var buff = BufferUtil.alloc(this.degree)
     remainder.copy(buff, start)
 
     return buff

--- a/lib/utils/buffer.js
+++ b/lib/utils/buffer.js
@@ -1,1 +1,2 @@
-module.exports = require('buffer').Buffer
+module.exports.alloc = require('buffer-alloc')
+module.exports.from = require('buffer-from')

--- a/lib/utils/typedarray-buffer.js
+++ b/lib/utils/typedarray-buffer.js
@@ -509,4 +509,12 @@ Buffer.isBuffer = function isBuffer (b) {
   return !!(b != null && b._isBuffer)
 }
 
-module.exports = Buffer
+module.exports.alloc = function (size) {
+  var buffer = new Buffer(size)
+  buffer.fill(0)
+  return buffer
+}
+
+module.exports.from = function (data) {
+  return new Buffer(data)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -548,11 +548,29 @@
         "ieee754": "^1.1.4"
       }
     },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-xor": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "lint": "standard",
     "pretest": "npm run lint",
-    "test": "node test.js",
+    "test": "node --throw-deprecation test.js",
     "build": "node build.js",
     "prepublish": "npm run build"
   },
@@ -37,6 +37,8 @@
     "qrcode": "./bin/qrcode"
   },
   "dependencies": {
+    "buffer-alloc": "^1.2.0",
+    "buffer-from": "^1.1.1",
     "dijkstrajs": "^1.0.1",
     "isarray": "^2.0.1",
     "pngjs": "^3.3.0",

--- a/test/unit/core/mask-pattern.test.js
+++ b/test/unit/core/mask-pattern.test.js
@@ -1,6 +1,7 @@
 var test = require('tap').test
 var BitMatrix = require('core/bit-matrix')
 var MaskPattern = require('core/mask-pattern')
+var BufferUtil = require('utils/buffer')
 
 test('Mask pattern - Pattern references', function (t) {
   var patternsCount = Object.keys(MaskPattern.Patterns).length
@@ -109,7 +110,7 @@ test('Mask pattern - Apply mask', function (t) {
   for (var p = 0; p < patterns; p++) {
     var matrix = new BitMatrix(6)
     MaskPattern.applyMask(p, matrix)
-    t.deepEqual(matrix.data, new Buffer(expectedPatterns[p]), 'Should return correct pattern')
+    t.deepEqual(matrix.data, BufferUtil.from(expectedPatterns[p]), 'Should return correct pattern')
   }
 
   matrix = new BitMatrix(2)
@@ -119,7 +120,7 @@ test('Mask pattern - Apply mask', function (t) {
   matrix.set(1, 1, false, true)
   MaskPattern.applyMask(0, matrix)
 
-  t.deepEqual(matrix.data, new Buffer([false, false, false, false]), 'Should leave reserved bit unchanged')
+  t.deepEqual(matrix.data, BufferUtil.from([false, false, false, false]), 'Should leave reserved bit unchanged')
 
   t.throws(function () { MaskPattern.applyMask(-1, new BitMatrix(1)) }, 'Should throw if pattern is invalid')
 

--- a/test/unit/core/polynomial.test.js
+++ b/test/unit/core/polynomial.test.js
@@ -1,10 +1,11 @@
 var test = require('tap').test
 var Poly = require('core/polynomial')
+var BufferUtil = require('utils/buffer')
 
 test('Generator polynomial', function (t) {
   var result = Poly.generateECPolynomial(0)
   t.ok(Buffer.isBuffer(result), 'Should return a buffer')
-  t.deepEqual(result, new Buffer([1]), 'Should return coeff [1] for polynomial of degree 0')
+  t.deepEqual(result, BufferUtil.from([1]), 'Should return coeff [1] for polynomial of degree 0')
 
   for (var e = 2; e <= 68; e++) {
     t.equal(Poly.generateECPolynomial(e).length, e + 1, 'Should return a number of coefficients equal to (degree + 1)')

--- a/test/unit/core/reed-solomon-encoder.test.js
+++ b/test/unit/core/reed-solomon-encoder.test.js
@@ -1,5 +1,6 @@
 var test = require('tap').test
 var RS = require('core/reed-solomon-encoder')
+var BufferUtil = require('utils/buffer')
 
 test('Reed-Solomon encoder', function (t) {
   var enc = new RS()
@@ -11,7 +12,7 @@ test('Reed-Solomon encoder', function (t) {
   t.equal(enc.degree, 2, 'Should set correct degree value')
   t.ok(enc.genPoly, 'Generator polynomial should be defined')
 
-  var result = enc.encode(new Buffer('01234'))
+  var result = enc.encode(BufferUtil.from('01234'))
   t.equal(result.length, 2, 'Should return a number of codewords equal to gen poly degree')
 
   enc = new RS(2)
@@ -26,7 +27,7 @@ test('Reed-Solomon encoder', function (t) {
   t.notOk(enc.genPoly, 'Should not create a generator polynomial if degree is 0')
 
   enc = new RS(1)
-  t.deepEqual(enc.encode(new Buffer([0])), new Buffer([0]),
+  t.deepEqual(enc.encode(BufferUtil.from([0])), BufferUtil.from([0]),
     'Should return correct buffer')
 
   t.end()


### PR DESCRIPTION
This avoids using the deprecated Buffer APIs in Node.js, which logs warnings to the console when they are used.

It also adds the flag `--throw-deprecation` to the tests, which will make sure that we don't inadvertently use any deprecated apis again.

Long term I think it would be great if we could move from using `Buffer` to just using `Uint8Array`, if I get the time I'll submit that PR later ☺️ 

