### PR TITLE
Add support for structured append segments

### DIFF
--- a/lib/core/mode.js
+++ b/lib/core/mode.js
@@ -56,6 +56,17 @@ exports.KANJI = {
 }
 
 /**
+ * Structured append mode contains information about a sequence of
+ * multiple QR codes. This segment is always a fixed size, so no
+ * character count indicator is required.
+ */
+exports.STRUCTURED_APPEND = {
+  id: 'Structured Append',
+  bit: (1 << 0) | (1 << 1),
+  ccBits: [0, 0, 0]
+}
+
+/**
  * Mixed mode will contain a sequences of data in a combination of any of
  * the modes described above
  *
@@ -141,6 +152,8 @@ function fromString (string) {
       return exports.KANJI
     case 'byte':
       return exports.BYTE
+    case 'structuredappend':
+      return exports.STRUCTURED_APPEND
     default:
       throw new Error('Unknown mode: ' + string)
   }

--- a/lib/core/segments.js
+++ b/lib/core/segments.js
@@ -3,6 +3,7 @@ var NumericData = require('./numeric-data')
 var AlphanumericData = require('./alphanumeric-data')
 var ByteData = require('./byte-data')
 var KanjiData = require('./kanji-data')
+var StructuredAppendData = require('./structured-append-data')
 var Regex = require('./regex')
 var Utils = require('./utils')
 var dijkstra = require('dijkstrajs')
@@ -95,6 +96,8 @@ function getSegmentBitsLength (length, mode) {
       return KanjiData.getBitsLength(length)
     case Mode.BYTE:
       return ByteData.getBitsLength(length)
+    case Mode.STRUCTUREDAPPEND:
+      return StructuredAppendData.getBitsLength(length)
   }
 }
 
@@ -237,7 +240,7 @@ function buildSingleSegment (data, modesHint) {
   mode = Mode.from(modesHint, bestMode)
 
   // Make sure data can be encoded
-  if (mode !== Mode.BYTE && mode.bit < bestMode.bit) {
+  if (mode !== Mode.BYTE && mode !== Mode.STRUCTURED_APPEND && mode.bit < bestMode.bit) {
     throw new Error('"' + data + '"' +
       ' cannot be encoded with mode ' + Mode.toString(mode) +
       '.\n Suggested mode is: ' + Mode.toString(bestMode))
@@ -260,6 +263,9 @@ function buildSingleSegment (data, modesHint) {
 
     case Mode.BYTE:
       return new ByteData(data)
+
+    case Mode.STRUCTURED_APPEND:
+      return new StructuredAppendData(data)
   }
 }
 

--- a/lib/core/structured-append-data.js
+++ b/lib/core/structured-append-data.js
@@ -1,0 +1,26 @@
+var Mode = require('./mode')
+
+function StructuredAppendData (data) {
+  this.mode = Mode.STRUCTURED_APPEND
+  this.data = data
+}
+
+StructuredAppendData.getBitsLength = function getBitsLength () {
+  return 16
+}
+
+StructuredAppendData.prototype.getLength = function getLength () {
+  return 0
+}
+
+StructuredAppendData.prototype.getBitsLength = function getBitsLength () {
+  return StructuredAppendData.getBitsLength()
+}
+
+StructuredAppendData.prototype.write = function (bitBuffer) {
+  bitBuffer.put(this.data.position, 4)
+  bitBuffer.put(this.data.total, 4)
+  bitBuffer.put(this.data.parity, 8)
+}
+
+module.exports = StructuredAppendData

--- a/test/unit/core/mode.test.js
+++ b/test/unit/core/mode.test.js
@@ -7,6 +7,7 @@ test('Mode bits', function (t) {
     alphanumeric: 2,
     byte: 4,
     kanji: 8,
+    structuredappend: 3,
     mixed: -1
   }
 
@@ -14,6 +15,7 @@ test('Mode bits', function (t) {
   t.equal(Mode.ALPHANUMERIC.bit, EXPECTED_BITS.alphanumeric)
   t.equal(Mode.BYTE.bit, EXPECTED_BITS.byte)
   t.equal(Mode.KANJI.bit, EXPECTED_BITS.kanji)
+  t.equal(Mode.STRUCTURED_APPEND.bit, EXPECTED_BITS.structuredappend)
   t.equal(Mode.MIXED.bit, EXPECTED_BITS.mixed)
 
   t.end()
@@ -24,7 +26,8 @@ test('Char count bits', function (t) {
     numeric: [10, 12, 14],
     alphanumeric: [9, 11, 13],
     byte: [8, 16, 16],
-    kanji: [8, 10, 12]
+    kanji: [8, 10, 12],
+    structuredappend: [0, 0, 0]
   }
 
   var v
@@ -33,6 +36,7 @@ test('Char count bits', function (t) {
     t.equal(Mode.getCharCountIndicator(Mode.ALPHANUMERIC, v), EXPECTED_BITS.alphanumeric[0])
     t.equal(Mode.getCharCountIndicator(Mode.BYTE, v), EXPECTED_BITS.byte[0])
     t.equal(Mode.getCharCountIndicator(Mode.KANJI, v), EXPECTED_BITS.kanji[0])
+    t.equal(Mode.getCharCountIndicator(Mode.STRUCTURED_APPEND, v), EXPECTED_BITS.structuredappend[0])
   }
 
   for (v = 10; v < 27; v++) {
@@ -40,6 +44,7 @@ test('Char count bits', function (t) {
     t.equal(Mode.getCharCountIndicator(Mode.ALPHANUMERIC, v), EXPECTED_BITS.alphanumeric[1])
     t.equal(Mode.getCharCountIndicator(Mode.BYTE, v), EXPECTED_BITS.byte[1])
     t.equal(Mode.getCharCountIndicator(Mode.KANJI, v), EXPECTED_BITS.kanji[1])
+    t.equal(Mode.getCharCountIndicator(Mode.STRUCTURED_APPEND, v), EXPECTED_BITS.structuredappend[1])
   }
 
   for (v = 27; v <= 40; v++) {
@@ -47,6 +52,7 @@ test('Char count bits', function (t) {
     t.equal(Mode.getCharCountIndicator(Mode.ALPHANUMERIC, v), EXPECTED_BITS.alphanumeric[2])
     t.equal(Mode.getCharCountIndicator(Mode.BYTE, v), EXPECTED_BITS.byte[2])
     t.equal(Mode.getCharCountIndicator(Mode.KANJI, v), EXPECTED_BITS.kanji[2])
+    t.equal(Mode.getCharCountIndicator(Mode.STRUCTURED_APPEND, v), EXPECTED_BITS.structuredappend[2])
   }
 
   t.throw(function () { Mode.getCharCountIndicator({}, 1) },
@@ -84,6 +90,7 @@ test('Is valid', function (t) {
   t.ok(Mode.isValid(Mode.ALPHANUMERIC))
   t.ok(Mode.isValid(Mode.BYTE))
   t.ok(Mode.isValid(Mode.KANJI))
+  t.ok(Mode.isValid(Mode.STRUCTURED_APPEND))
 
   t.notOk(Mode.isValid(undefined))
   t.notOk(Mode.isValid({ bit: 1 }))
@@ -97,7 +104,8 @@ test('From value', function (t) {
     { name: 'numeric', mode: Mode.NUMERIC },
     { name: 'alphanumeric', mode: Mode.ALPHANUMERIC },
     { name: 'kanji', mode: Mode.KANJI },
-    { name: 'byte', mode: Mode.BYTE }
+    { name: 'byte', mode: Mode.BYTE },
+    { name: 'structuredappend', mode: Mode.STRUCTURED_APPEND }
   ]
 
   for (var m = 0; m < modes.length; m++) {
@@ -120,6 +128,7 @@ test('To string', function (t) {
   t.equal(Mode.toString(Mode.ALPHANUMERIC), 'Alphanumeric')
   t.equal(Mode.toString(Mode.BYTE), 'Byte')
   t.equal(Mode.toString(Mode.KANJI), 'Kanji')
+  t.equal(Mode.toString(Mode.STRUCTURED_APPEND), 'Structured Append')
 
   t.throw(function () { Mode.toString({}) }, 'Should throw if mode is invalid')
 

--- a/test/unit/core/segments.test.js
+++ b/test/unit/core/segments.test.js
@@ -4,6 +4,7 @@ var Segments = require('core/segments')
 var NumericData = require('core/numeric-data')
 var AlphanumericData = require('core/alphanumeric-data')
 var ByteData = require('core/byte-data')
+var StructuredAppendData = require('core/structured-append-data')
 var toSJIS = require('helper/to-sjis')
 var Utils = require('core/utils')
 
@@ -191,6 +192,11 @@ test('Segments from array', function (t) {
   t.deepEqual(Segments.fromArray(
     [{ data: '０１２３', mode: Mode.KANJI }]), [new ByteData('０１２３')],
     'Should use Byte mode if kanji support is disabled')
+
+  t.deepEqual(Segments.fromArray(
+    [{ data: { position: 0x1, total: 0x3, parity: 0x0A }, mode: 'structuredappend' }]),
+    [new StructuredAppendData({ position: 0x1, total: 0x3, parity: 0x0A })],
+    'Should use Structured Append mode')
 
   t.end()
 })

--- a/test/unit/core/structured-append-data.test.js
+++ b/test/unit/core/structured-append-data.test.js
@@ -1,0 +1,22 @@
+var test = require('tap').test
+var BitBuffer = require('core/bit-buffer')
+var StructuredAppendData = require('core/structured-append-data')
+var Mode = require('core/mode')
+
+test('Structured Append Data', function (t) {
+  var data = { position: 0x1, total: 0x3, parity: 0x0A }
+
+  var bytes = [0x13, 0xA]
+
+  var structuredAppendData = new StructuredAppendData(data)
+
+  t.equal(structuredAppendData.mode, Mode.STRUCTURED_APPEND, 'Mode should be STRUCTURED_APPEND')
+  t.equal(structuredAppendData.getLength(), 0, 'Should return correct length')
+  t.equal(structuredAppendData.getBitsLength(), 16, 'Should return correct bit length')
+
+  var bitBuffer = new BitBuffer()
+  structuredAppendData.write(bitBuffer)
+  t.deepEqual(bitBuffer.buffer, bytes, 'Should write correct data to buffer')
+
+  t.end()
+})


### PR DESCRIPTION
This change adds support for structured append segments (#178). Here's a usage example:

```js
QRCode.toFile('test.png', [
  { mode: 'structuredappend', data: { position: 0x0, total: 0x3, parity: 0x0A } },
  { mode: 'byte', data: [0x01, 0x02, 0x03] }
])
```

This generates the following QR code:

![test](https://user-images.githubusercontent.com/1619746/78208140-7bbab880-7458-11ea-8d06-c03d21f34428.png)

I confirmed functionality by testing the QR code with [this reader](https://zxing.org/w/decode.jspx) and it found the following bytes:

```
30 30 a4 03 01 02 03 00   ec 11 ec 11 ec 11 ec 11
```
3 - the mode indicator for structured append mode (0011)
0 - the current symbol position (indicating this is the 1st QR code)
3 - the total number of symbols (there are a total of 4 QR codes)
0A - the parity byte (as specified)

The parity byte is a little tricky because it's based on the total XOR sum of all the content bytes for the *entire* payload, spanning across multiple QR codes. There's no way to calculate it based on a single QR code's content, so the assumption here is that you would calculate the parity byte yourself before generating the QR codes, and just pass in whatever you found for the result.

Effectively, the parity byte doesn't really matter much because I think a lot of QR code readers don't actually verify it. I've seen implementations that just generate a random byte value rather than actually calculating what the value should be and they seem to work without issue.

Anyway, let me know if you notice any issues! 😃 