### PR TITLE
add esm build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 coverage
 .nyc_output
 build
+dist

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "./lib/index.js": "./lib/browser.js",
     "fs": false
   },
+  "module": "./dist/qrcode.esm.js",
   "files": [
     "bin",
     "build",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,4 +16,8 @@ export default [{
   input: 'helper/to-sjis-browser.js',
   output: { file: 'build/qrcode.tosjis.js', format: 'iife', exports: 'none' },
   plugins: [commonjs(), resolve(), babel(babelConfig), terser()]
+}, {
+  input: 'lib/browser.js',
+  output: { file: 'dist/qrcode.esm.js', format: 'esm', name: 'QRCode', exports: 'named' },
+  plugins: [commonjs(), resolve(), babel(babelConfig), terser()]
 }]


### PR DESCRIPTION
This is a proof of concept intended to address #236. There are a few decisions remaining involving where files should be located, whether or not to still include an IIFE version, and what to do about SJIS, but I can at least report that I can build and use this with `npm link`, include it in an Angular 10 Ivy project, get no warnings about CommonJS, and QR codes seem to display as before in the app when deployed.

The conversion to use rollup made by @LinusU in [9e702a1](https://github.com/soldair/node-qrcode/commit/9e702a11418f08ad540f295572c3238159cce064) did all the real heavy lifting here.