### PR TITLE
rendering of svg now also accepts scale option

### DIFF
--- a/lib/renderer/svg-tag.js
+++ b/lib/renderer/svg-tag.js
@@ -69,7 +69,8 @@ exports.render = function render (qrData, options, cb) {
 
   const viewBox = 'viewBox="' + '0 0 ' + qrcodesize + ' ' + qrcodesize + '"'
 
-  const width = !opts.width ? '' : 'width="' + opts.width + '" height="' + opts.width + '" '
+  const scale = !opts.scale ? '' : 'width="' + qrcodesize * opts.scale + '" height="' + qrcodesize * opts.scale + '" '
+  const width = !opts.width ? scale : 'width="' + opts.width + '" height="' + opts.width + '" '
 
   const svgTag = '<svg xmlns="http://www.w3.org/2000/svg" ' + width + viewBox + ' shape-rendering="crispEdges">' + bg + path + '</svg>\n'
 


### PR DESCRIPTION
Also use the scale option when creating a SVG, width option will override scale.