### PR TITLE
Remove typescript ignore mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,8 +350,6 @@ QRCode.toFile(
 )
 ```
 
-TypeScript users: if you are using [@types/qrcode](https://www.npmjs.com/package/@types/qrcode), you will need to add a `// @ts-ignore` above the data segment because it expects `data: string`.
-
 ## Multibyte characters
 Support for multibyte characters isn't present in the initial QR Code standard, but is possible to encode UTF-8 characters in Byte mode.
 


### PR DESCRIPTION
Hey !

As this PR https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51041 was merged, the ts-ignore mention on the README.md doesn't need to be present anymore.