### PR TITLE
Fix missing return in `toFileStream`

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -134,5 +134,5 @@ exports.toFileStream = function toFileStream (stream, text, opts) {
   const params = checkParams(text, opts, stream.emit.bind(stream, 'error'))
   const renderer = getRendererFromType('png') // Only png support for now
   const renderToFileStream = renderer.renderToFileStream.bind(null, stream)
-  render(renderToFileStream, text, params)
+  return render(renderToFileStream, text, params)
 }


### PR DESCRIPTION
Breaks the "promise" version of `toFileStream` as you can't chain promises off the result.