### PR TITLE
fix: entry is wrong

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "canvas",
     "qrcode"
   ],
-  "main": "./lib/index.js",
+  "main": "./build/qrcode.js",
   "browser": {
     "./lib/index.js": "./lib/browser.js",
     "fs": false


### PR DESCRIPTION
When I updated version 1.5.0, I found that there was no Babel translation.plz check this