### PR TITLE
fix: binary data not working as described (fixes #289, #231)

### DIFF
--- a/lib/core/byte-data.js
+++ b/lib/core/byte-data.js
@@ -3,7 +3,10 @@ const Mode = require('./mode')
 
 function ByteData (data) {
   this.mode = Mode.BYTE
-  this.data = new Uint8Array(encodeUtf8(data))
+  if (typeof (data) === 'string') {
+    data = encodeUtf8(data)
+  }
+  this.data = new Uint8Array(data)
 }
 
 ByteData.getBitsLength = function getBitsLength (length) {

--- a/test/e2e/toString.test.js
+++ b/test/e2e/toString.test.js
@@ -231,3 +231,31 @@ test('toString terminal', function (t) {
     t.equal(code + '\n', expectedTerminal, 'should output a valid symbol (promise)')
   })
 })
+
+test('toString byte-input', function (t) {
+  const expectedOutput = [
+    '                             ',
+    '                             ',
+    '    █▀▀▀▀▀█  █▄█▀ █▀▀▀▀▀█    ',
+    '    █ ███ █ ▀█ █▀ █ ███ █    ',
+    '    █ ▀▀▀ █   ▀ █ █ ▀▀▀ █    ',
+    '    ▀▀▀▀▀▀▀ █▄▀▄█ ▀▀▀▀▀▀▀    ',
+    '    ▀██▄██▀▀▀█▀▀ ▀█  ▄▀▄     ',
+    '    ▀█▀▄█▄▀▄ ██ ▀ ▄ ▀▄  ▀    ',
+    '    ▀ ▀ ▀▀▀▀█▄ ▄▀▄▀▄▀▄▀▄▀    ',
+    '    █▀▀▀▀▀█ █  █▄█▀█▄█  ▀    ',
+    '    █ ███ █ ▀█▀▀ ▀██  ▀█▀    ',
+    '    █ ▀▀▀ █ ██▀ ▀ ▄ ▀▄▀▄▀    ',
+    '    ▀▀▀▀▀▀▀ ▀▀▀ ▀ ▀▀▀ ▀▀▀    ',
+    '                             ',
+    '                             '
+  ].join('\n')
+  const byteInput = new Uint8ClampedArray([1, 2, 3, 4, 5])
+
+  t.plan(2)
+
+  QRCode.toString([{ data: byteInput, mode: 'byte' }], { errorCorrectionLevel: 'L' }, (err, code) => {
+    t.ok(!err, 'there should be no error')
+    t.equal(code, expectedOutput, 'should output the correct code')
+  })
+})

--- a/test/unit/core/byte-data.test.js
+++ b/test/unit/core/byte-data.test.js
@@ -3,7 +3,7 @@ const BitBuffer = require('core/bit-buffer')
 const ByteData = require('core/byte-data')
 const Mode = require('core/mode')
 
-test('Byte Data', function (t) {
+test('Byte Data: String Input', function (t) {
   const text = '1234'
   const textBitLength = 32
   const textByte = [49, 50, 51, 52] // 1, 2, 3, 4
@@ -21,6 +21,20 @@ test('Byte Data', function (t) {
 
   const byteDataUtf8 = new ByteData(utf8Text)
   t.equal(byteDataUtf8.getLength(), 12, 'Should return correct length for utf8 chars')
+
+  t.end()
+})
+
+test('Byte Data: Byte Input', function (t) {
+  const bytes = new Uint8ClampedArray([1, 231, 32, 22])
+
+  const byteData = new ByteData(bytes)
+  t.equal(byteData.getLength(), bytes.length, 'Should return correct length')
+  t.equal(byteData.getBitsLength(), bytes.length * 8, 'Should return correct bit length')
+
+  const bitBuffer = new BitBuffer()
+  byteData.write(bitBuffer)
+  t.deepEqual(bitBuffer.buffer, bytes, 'Should write correct data to buffer')
 
   t.end()
 })


### PR DESCRIPTION
Fixed binary data not working as input as described in the README.md. 
Fixes #289, fixes #231.

Tests were also added, one unit test and one e2e test, each in its own commit.

_Note:
I wasnt sure whether or not the place for the fix was right. I could also adapt `ByteData` to only accept `ArrayBuffer` or similar and make the string conversion in the files using this class (e.g. `segments.js`). Please let me know it you want me to change that._


