### PR TITLE
Update README.md to reflect correct usage of "import"

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ QRCode.toString('I am a pony!',{type:'terminal'}, function (err, url) {
 Promises and Async/Await can be used in place of callback function.
 
 ```javascript
-import QRCode from 'qrcode'
+import * as QRCode from 'qrcode'
 
 // With promises
 QRCode.toDataURL('I am a pony!')


### PR DESCRIPTION
There are a number of issues: #281, #282, #242 which appear to be falling down on the import not working correctly.

The imports in these issues use:
`import QRCode from 'qrcode'`

But this results in QRCode as being `undefined`.

As #281 and #186 state, this import appears to work:
`import * as QRCode from 'qrcode'`

Ideally, the documented method would work, but it doesn't.  Thus this PR updates the documentation to show the method that *does* work.