### PR TITLE
Update pngjs to 6.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5167,9 +5167,9 @@
       }
     },
     "pngjs": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
-      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "dijkstrajs": "^1.0.1",
     "encode-utf8": "^1.0.3",
-    "pngjs": "^5.0.0",
+    "pngjs": "^6.0.0",
     "yargs": "^15.3.1"
   },
   "devDependencies": {
@@ -66,7 +66,7 @@
     "url": "git://github.com/soldair/node-qrcode.git"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.13.0"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
6.x of pngjs drops node 10 support, so it will require this library as well to update to at least the next LTS as minimum. Both node 10 and 12 have been out of support for several years, though, but perhaps this should be released in a new major version anyway.