### PR TITLE
Replace deprecated `tap` functions

### DIFF
--- a/test/e2e/toCanvas.test.js
+++ b/test/e2e/toCanvas.test.js
@@ -16,16 +16,16 @@ test('toCanvas - no promise available', function (t) {
   }
   const canvasEl = createCanvas(200, 200)
 
-  t.throw(function () { QRCode.toCanvas() },
+  t.throws(function () { QRCode.toCanvas() },
     'Should throw if no arguments are provided')
 
-  t.throw(function () { QRCode.toCanvas('some text') },
+  t.throws(function () { QRCode.toCanvas('some text') },
     'Should throw if a callback is not provided')
 
-  t.throw(function () { QRCode.toCanvas(canvasEl, 'some text') },
+  t.throws(function () { QRCode.toCanvas(canvasEl, 'some text') },
     'Should throw if a callback is not provided')
 
-  t.throw(function () { QRCode.toCanvas(canvasEl, 'some text', {}) },
+  t.throws(function () { QRCode.toCanvas(canvasEl, 'some text', {}) },
     'Should throw if callback is not a function')
 
   t.end()
@@ -46,7 +46,7 @@ test('toCanvas', function (t) {
 
   t.plan(7)
 
-  t.throw(function () { QRCode.toCanvas() },
+  t.throws(function () { QRCode.toCanvas() },
     'Should throw if no arguments are provided')
 
   QRCode.toCanvas('some text', function (err, canvasEl) {

--- a/test/e2e/toDataURL.test.js
+++ b/test/e2e/toDataURL.test.js
@@ -7,28 +7,28 @@ const Helpers = require('test/helpers')
 test('toDataURL - no promise available', function (t) {
   Helpers.removeNativePromise()
 
-  t.throw(function () { QRCode.toDataURL() },
+  t.throws(function () { QRCode.toDataURL() },
     'Should throw if no arguments are provided')
 
-  t.throw(function () { QRCode.toDataURL(function () {}) },
+  t.throws(function () { QRCode.toDataURL(function () {}) },
     'Should throw if text is not provided')
 
-  t.throw(function () { QRCode.toDataURL('some text') },
+  t.throws(function () { QRCode.toDataURL('some text') },
     'Should throw if a callback is not provided')
 
-  t.throw(function () { QRCode.toDataURL('some text', {}) },
+  t.throws(function () { QRCode.toDataURL('some text', {}) },
     'Should throw if a callback is not a function')
 
-  t.throw(function () { QRCodeBrowser.toDataURL() },
+  t.throws(function () { QRCodeBrowser.toDataURL() },
     'Should throw if no arguments are provided (browser)')
 
-  t.throw(function () { QRCodeBrowser.toDataURL(function () {}) },
+  t.throws(function () { QRCodeBrowser.toDataURL(function () {}) },
     'Should throw if text is not provided (browser)')
 
-  t.throw(function () { QRCodeBrowser.toDataURL('some text') },
+  t.throws(function () { QRCodeBrowser.toDataURL('some text') },
     'Should throw if a callback is not provided (browser)')
 
-  t.throw(function () { QRCodeBrowser.toDataURL('some text', {}) },
+  t.throws(function () { QRCodeBrowser.toDataURL('some text', {}) },
     'Should throw if a callback is not a function (browser)')
 
   t.end()
@@ -57,7 +57,7 @@ test('toDataURL - image/png', function (t) {
 
   t.plan(8)
 
-  t.throw(function () { QRCode.toDataURL() },
+  t.throws(function () { QRCode.toDataURL() },
     'Should throw if no arguments are provided')
 
   QRCode.toDataURL('i am a pony!', {
@@ -120,10 +120,10 @@ test('Canvas toDataURL - image/png', function (t) {
 
   t.plan(11)
 
-  t.throw(function () { QRCodeBrowser.toDataURL() },
+  t.throws(function () { QRCodeBrowser.toDataURL() },
     'Should throw if no arguments are provided')
 
-  t.throw(function () { QRCodeBrowser.toDataURL(function () {}) },
+  t.throws(function () { QRCodeBrowser.toDataURL(function () {}) },
     'Should throw if text is not provided')
 
   const canvas = createCanvas(200, 200)

--- a/test/e2e/toDataURL.test.js
+++ b/test/e2e/toDataURL.test.js
@@ -65,7 +65,7 @@ test('toDataURL - image/png', function (t) {
     type: 'image/png'
   }, function (err, url) {
     t.ok(!err, 'there should be no error ' + err)
-    t.equals(url, expectedDataURL,
+    t.equal(url, expectedDataURL,
       'url should match expected value for error correction L')
   })
 
@@ -78,14 +78,14 @@ test('toDataURL - image/png', function (t) {
     t.notOk(url, 'url should be null')
   })
 
-  t.equals(typeof QRCode.toDataURL('i am a pony!').then, 'function',
+  t.equal(typeof QRCode.toDataURL('i am a pony!').then, 'function',
     'Should return a promise')
 
   QRCode.toDataURL('i am a pony!', {
     errorCorrectionLevel: 'L',
     type: 'image/png'
   }).then(function (url) {
-    t.equals(url, expectedDataURL,
+    t.equal(url, expectedDataURL,
       'url should match expected value for error correction L (promise)')
   })
 
@@ -132,7 +132,7 @@ test('Canvas toDataURL - image/png', function (t) {
     type: 'image/png'
   }, function (err, url) {
     t.ok(!err, 'there should be no error ' + err)
-    t.equals(url, expectedDataURL, 'url generated should match expected value')
+    t.equal(url, expectedDataURL, 'url generated should match expected value')
   })
 
   QRCodeBrowser.toDataURL(canvas, 'i am a pony!', {
@@ -148,7 +148,7 @@ test('Canvas toDataURL - image/png', function (t) {
     errorCorrectionLevel: 'H',
     type: 'image/png'
   }).then(function (url) {
-    t.equals(url, expectedDataURL, 'url generated should match expected value (promise)')
+    t.equal(url, expectedDataURL, 'url generated should match expected value (promise)')
   })
 
   QRCodeBrowser.toDataURL(canvas, 'i am a pony!', {
@@ -173,13 +173,13 @@ test('Canvas toDataURL - image/png', function (t) {
     type: 'image/png'
   }, function (err, url) {
     t.ok(!err, 'there should be no error ' + err)
-    t.equals(url, expectedDataURL, 'url generated should match expected value')
+    t.equal(url, expectedDataURL, 'url generated should match expected value')
   })
 
   QRCodeBrowser.toDataURL('i am a pony!', {
     errorCorrectionLevel: 'H',
     type: 'image/png'
   }).then(function (url) {
-    t.equals(url, expectedDataURL, 'url generated should match expected value (promise)')
+    t.equal(url, expectedDataURL, 'url generated should match expected value (promise)')
   })
 })

--- a/test/e2e/toFile.test.js
+++ b/test/e2e/toFile.test.js
@@ -11,10 +11,10 @@ test('toFile - no promise available', function (t) {
   Helpers.removeNativePromise()
   const fileName = path.join(os.tmpdir(), 'qrimage.png')
 
-  t.throw(function () { QRCode.toFile(fileName, 'some text') },
+  t.throws(function () { QRCode.toFile(fileName, 'some text') },
     'Should throw if a callback is not provided')
 
-  t.throw(function () { QRCode.toFile(fileName, 'some text', {}) },
+  t.throws(function () { QRCode.toFile(fileName, 'some text', {}) },
     'Should throw if a callback is not a function')
 
   t.end()
@@ -25,10 +25,10 @@ test('toFile - no promise available', function (t) {
 test('toFile', function (t) {
   const fileName = path.join(os.tmpdir(), 'qrimage.png')
 
-  t.throw(function () { QRCode.toFile('some text', function () {}) },
+  t.throws(function () { QRCode.toFile('some text', function () {}) },
     'Should throw if path is not provided')
 
-  t.throw(function () { QRCode.toFile(fileName) },
+  t.throws(function () { QRCode.toFile(fileName) },
     'Should throw if text is not provided')
 
   t.equal(typeof QRCode.toFile(fileName, 'some text').then, 'function',

--- a/test/e2e/toFileStream.test.js
+++ b/test/e2e/toFileStream.test.js
@@ -4,10 +4,10 @@ const QRCode = require('lib')
 const StreamMock = require('../mocks/writable-stream')
 
 test('toFileStream png', function (t) {
-  t.throw(function () { QRCode.toFileStream('some text') },
+  t.throws(function () { QRCode.toFileStream('some text') },
     'Should throw if stream is not provided')
 
-  t.throw(function () { QRCode.toFileStream(new StreamMock()) },
+  t.throws(function () { QRCode.toFileStream(new StreamMock()) },
     'Should throw if text is not provided')
 
   const fstream = new StreamMock()

--- a/test/e2e/toString.test.js
+++ b/test/e2e/toString.test.js
@@ -8,22 +8,22 @@ const Helpers = require('test/helpers')
 test('toString - no promise available', function (t) {
   Helpers.removeNativePromise()
 
-  t.throw(function () { QRCode.toString() },
+  t.throws(function () { QRCode.toString() },
     'Should throw if text is not provided')
 
-  t.throw(function () { QRCode.toString('some text') },
+  t.throws(function () { QRCode.toString('some text') },
     'Should throw if a callback is not provided')
 
-  t.throw(function () { QRCode.toString('some text', {}) },
+  t.throws(function () { QRCode.toString('some text', {}) },
     'Should throw if a callback is not a function')
 
-  t.throw(function () { QRCode.toString() },
+  t.throws(function () { QRCode.toString() },
     'Should throw if text is not provided (browser)')
 
-  t.throw(function () { browser.toString('some text') },
+  t.throws(function () { browser.toString('some text') },
     'Should throw if a callback is not provided (browser)')
 
-  t.throw(function () { browser.toString('some text', {}) },
+  t.throws(function () { browser.toString('some text', {}) },
     'Should throw if a callback is not a function (browser)')
 
   t.end()
@@ -34,7 +34,7 @@ test('toString - no promise available', function (t) {
 test('toString', function (t) {
   t.plan(5)
 
-  t.throw(function () { QRCode.toString() },
+  t.throws(function () { QRCode.toString() },
     'Should throw if text is not provided')
 
   QRCode.toString('some text', function (err, str) {
@@ -56,7 +56,7 @@ test('toString', function (t) {
 test('toString (browser)', function (t) {
   t.plan(5)
 
-  t.throw(function () { browser.toString() },
+  t.throws(function () { browser.toString() },
     'Should throw if text is not provided')
 
   browser.toString('some text', function (err, str) {

--- a/test/e2e/toString.test.js
+++ b/test/e2e/toString.test.js
@@ -39,16 +39,16 @@ test('toString', function (t) {
 
   QRCode.toString('some text', function (err, str) {
     t.ok(!err, 'There should be no error')
-    t.equals(typeof str, 'string',
+    t.equal(typeof str, 'string',
       'Should return a string')
   })
 
-  t.equals(typeof QRCode.toString('some text').then, 'function',
+  t.equal(typeof QRCode.toString('some text').then, 'function',
     'Should return a promise')
 
   QRCode.toString('some text', { errorCorrectionLevel: 'L' })
     .then(function (str) {
-      t.equals(typeof str, 'string',
+      t.equal(typeof str, 'string',
         'Should return a string')
     })
 })
@@ -61,16 +61,16 @@ test('toString (browser)', function (t) {
 
   browser.toString('some text', function (err, str) {
     t.ok(!err, 'There should be no error (browser)')
-    t.equals(typeof str, 'string',
+    t.equal(typeof str, 'string',
       'Should return a string (browser)')
   })
 
-  t.equals(typeof browser.toString('some text').then, 'function',
+  t.equal(typeof browser.toString('some text').then, 'function',
     'Should return a promise')
 
   browser.toString('some text', { errorCorrectionLevel: 'L' })
     .then(function (str) {
-      t.equals(typeof str, 'string',
+      t.equal(typeof str, 'string',
         'Should return a string')
     })
 })

--- a/test/unit/core/alignment-pattern.test.js
+++ b/test/unit/core/alignment-pattern.test.js
@@ -55,7 +55,7 @@ test('Alignment pattern - Row/Col coords', function (t) {
 
   for (let i = 1; i <= 40; i++) {
     const pos = pattern.getRowColCoords(i)
-    t.deepEqual(pos, EXPECTED_POSITION_TABLE[i - 1], 'Should return correct coords')
+    t.same(pos, EXPECTED_POSITION_TABLE[i - 1], 'Should return correct coords')
   }
 })
 

--- a/test/unit/core/alignment-pattern.test.js
+++ b/test/unit/core/alignment-pattern.test.js
@@ -70,7 +70,7 @@ test('Alignment pattern - Positions', function (t) {
     // For each coord value check if it's present in the expected coords table
     pos.forEach(function (position) {
       position.forEach(function (coord) {
-        t.notEqual(expectedPos.indexOf(coord), -1, 'Should return valid coord value')
+        t.not(expectedPos.indexOf(coord), -1, 'Should return valid coord value')
       })
     })
   }

--- a/test/unit/core/alphanumeric-data.test.js
+++ b/test/unit/core/alphanumeric-data.test.js
@@ -34,7 +34,7 @@ test('Alphanumeric Data', function (t) {
 
     const bitBuffer = new BitBuffer()
     alphanumericData.write(bitBuffer)
-    t.deepEqual(bitBuffer.buffer, data.dataBit, 'Should write correct data to buffer')
+    t.same(bitBuffer.buffer, data.dataBit, 'Should write correct data to buffer')
   })
 
   t.end()

--- a/test/unit/core/bit-buffer.test.js
+++ b/test/unit/core/bit-buffer.test.js
@@ -13,7 +13,7 @@ test('Bit Buffer', function (t) {
   t.equal(bitBuffer.getLengthInBits(), 8, 'Length should be 8')
 
   for (let i = 0; i < 8; i++) {
-    t.deepEqual(bitBuffer.get(i), expectedDataBits[i], 'Should return correct bit value')
+    t.same(bitBuffer.get(i), expectedDataBits[i], 'Should return correct bit value')
   }
 
   t.end()

--- a/test/unit/core/bit-matrix.test.js
+++ b/test/unit/core/bit-matrix.test.js
@@ -2,8 +2,8 @@ const test = require('tap').test
 const BitMatrix = require('core/bit-matrix')
 
 test('Bit Matrix', function (t) {
-  t.throw(function () { BitMatrix(0) }, 'Should throw if size is 0')
-  t.throw(function () { BitMatrix(-1) }, 'Should throw if size less than 0')
+  t.throws(function () { BitMatrix(0) }, 'Should throw if size is 0')
+  t.throws(function () { BitMatrix(-1) }, 'Should throw if size less than 0')
 
   const bm = new BitMatrix(2)
 

--- a/test/unit/core/byte-data.test.js
+++ b/test/unit/core/byte-data.test.js
@@ -17,7 +17,7 @@ test('Byte Data: String Input', function (t) {
 
   const bitBuffer = new BitBuffer()
   byteData.write(bitBuffer)
-  t.deepEqual(bitBuffer.buffer, textByte, 'Should write correct data to buffer')
+  t.same(bitBuffer.buffer, textByte, 'Should write correct data to buffer')
 
   const byteDataUtf8 = new ByteData(utf8Text)
   t.equal(byteDataUtf8.getLength(), 12, 'Should return correct length for utf8 chars')
@@ -34,7 +34,7 @@ test('Byte Data: Byte Input', function (t) {
 
   const bitBuffer = new BitBuffer()
   byteData.write(bitBuffer)
-  t.deepEqual(bitBuffer.buffer, bytes, 'Should write correct data to buffer')
+  t.same(bitBuffer.buffer, bytes, 'Should write correct data to buffer')
 
   t.end()
 })

--- a/test/unit/core/galois-field.test.js
+++ b/test/unit/core/galois-field.test.js
@@ -2,7 +2,7 @@ const test = require('tap').test
 const GF = require('core/galois-field')
 
 test('Galois Field', function (t) {
-  t.throw(function () { GF.log(0) }, 'Should throw for log(n) with n < 1')
+  t.throws(function () { GF.log(0) }, 'Should throw for log(n) with n < 1')
 
   for (let i = 1; i < 255; i++) {
     t.equal(GF.log(GF.exp(i)), i, 'log and exp should be one the inverse of the other')

--- a/test/unit/core/kanji-data.test.js
+++ b/test/unit/core/kanji-data.test.js
@@ -20,7 +20,7 @@ test('Kanji Data', function (t) {
 
   let bitBuffer = new BitBuffer()
   kanjiData.write(bitBuffer)
-  t.deepEqual(bitBuffer.buffer, dataBit, 'Should write correct data to buffer')
+  t.same(bitBuffer.buffer, dataBit, 'Should write correct data to buffer')
 
   kanjiData = new KanjiData('abc')
   bitBuffer = new BitBuffer()

--- a/test/unit/core/kanji-data.test.js
+++ b/test/unit/core/kanji-data.test.js
@@ -24,7 +24,7 @@ test('Kanji Data', function (t) {
 
   kanjiData = new KanjiData('abc')
   bitBuffer = new BitBuffer()
-  t.throw(function () { kanjiData.write(bitBuffer) }, 'Should throw if data is invalid')
+  t.throws(function () { kanjiData.write(bitBuffer) }, 'Should throw if data is invalid')
 
   t.end()
 })

--- a/test/unit/core/mask-pattern.test.js
+++ b/test/unit/core/mask-pattern.test.js
@@ -109,7 +109,7 @@ test('Mask pattern - Apply mask', function (t) {
   for (let p = 0; p < patterns; p++) {
     const matrix = new BitMatrix(6)
     MaskPattern.applyMask(p, matrix)
-    t.deepEqual(matrix.data, new Uint8Array(expectedPatterns[p]), 'Should return correct pattern')
+    t.same(matrix.data, new Uint8Array(expectedPatterns[p]), 'Should return correct pattern')
   }
 
   const matrix = new BitMatrix(2)
@@ -119,7 +119,7 @@ test('Mask pattern - Apply mask', function (t) {
   matrix.set(1, 1, false, true)
   MaskPattern.applyMask(0, matrix)
 
-  t.deepEqual(matrix.data, new Uint8Array([false, false, false, false]), 'Should leave reserved bit unchanged')
+  t.same(matrix.data, new Uint8Array([false, false, false, false]), 'Should leave reserved bit unchanged')
 
   t.throws(function () { MaskPattern.applyMask(-1, new BitMatrix(1)) }, 'Should throw if pattern is invalid')
 

--- a/test/unit/core/mask-pattern.test.js
+++ b/test/unit/core/mask-pattern.test.js
@@ -4,7 +4,7 @@ const MaskPattern = require('core/mask-pattern')
 
 test('Mask pattern - Pattern references', function (t) {
   const patternsCount = Object.keys(MaskPattern.Patterns).length
-  t.equals(patternsCount, 8, 'Should return 8 patterns')
+  t.equal(patternsCount, 8, 'Should return 8 patterns')
 
   t.end()
 })
@@ -142,28 +142,28 @@ test('Mask pattern - Penalty N1', function (t) {
     0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1
   ]
 
-  t.equals(MaskPattern.getPenaltyN1(matrix), 59,
+  t.equal(MaskPattern.getPenaltyN1(matrix), 59,
     'Should return correct penalty points')
 
   matrix = new BitMatrix(6)
   matrix.data = expectedPattern000
 
-  t.equals(MaskPattern.getPenaltyN1(matrix), 0,
+  t.equal(MaskPattern.getPenaltyN1(matrix), 0,
     'Should return correct penalty points')
 
   matrix.data = expectedPattern001
 
-  t.equals(MaskPattern.getPenaltyN1(matrix), 24,
+  t.equal(MaskPattern.getPenaltyN1(matrix), 24,
     'Should return correct penalty points')
 
   matrix.data = expectedPattern010
 
-  t.equals(MaskPattern.getPenaltyN1(matrix), 24,
+  t.equal(MaskPattern.getPenaltyN1(matrix), 24,
     'Should return correct penalty points')
 
   matrix.data = expectedPattern101
 
-  t.equals(MaskPattern.getPenaltyN1(matrix), 20,
+  t.equal(MaskPattern.getPenaltyN1(matrix), 20,
     'Should return correct penalty points')
 
   t.end()
@@ -182,23 +182,23 @@ test('Mask pattern - Penalty N2', function (t) {
     1, 1, 0, 0, 1, 0, 1, 1
   ]
 
-  t.equals(MaskPattern.getPenaltyN2(matrix), 45,
+  t.equal(MaskPattern.getPenaltyN2(matrix), 45,
     'Should return correct penalty points')
 
   matrix = new BitMatrix(6)
   matrix.data = expectedPattern000
 
-  t.equals(MaskPattern.getPenaltyN2(matrix), 0,
+  t.equal(MaskPattern.getPenaltyN2(matrix), 0,
     'Should return correct penalty points')
 
   matrix.data = expectedPattern010
 
-  t.equals(MaskPattern.getPenaltyN2(matrix), 30,
+  t.equal(MaskPattern.getPenaltyN2(matrix), 30,
     'Should return correct penalty points')
 
   matrix.data = expectedPattern100
 
-  t.equals(MaskPattern.getPenaltyN2(matrix), 36,
+  t.equal(MaskPattern.getPenaltyN2(matrix), 36,
     'Should return correct penalty points')
 
   t.end()
@@ -220,7 +220,7 @@ test('Mask pattern - Penalty N3', function (t) {
     1, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0
   ]
 
-  t.equals(MaskPattern.getPenaltyN3(matrix), 160,
+  t.equal(MaskPattern.getPenaltyN3(matrix), 160,
     'Should return correct penalty points')
 
   matrix.data = [
@@ -237,7 +237,7 @@ test('Mask pattern - Penalty N3', function (t) {
     1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1
   ]
 
-  t.equals(MaskPattern.getPenaltyN3(matrix), 280,
+  t.equal(MaskPattern.getPenaltyN3(matrix), 280,
     'Should return correct penalty points')
 
   t.end()
@@ -247,19 +247,19 @@ test('Mask pattern - Penalty N4', function (t) {
   const matrix = new BitMatrix(10)
   matrix.data = new Array(50).fill(1).concat(new Array(50).fill(0))
 
-  t.equals(MaskPattern.getPenaltyN4(matrix), 0,
+  t.equal(MaskPattern.getPenaltyN4(matrix), 0,
     'Should return correct penalty points')
 
   const matrix2 = new BitMatrix(21)
   matrix2.data = new Array(190).fill(1).concat(new Array(251).fill(0))
 
-  t.equals(MaskPattern.getPenaltyN4(matrix2), 10,
+  t.equal(MaskPattern.getPenaltyN4(matrix2), 10,
     'Should return correct penalty points')
 
   const matrix3 = new BitMatrix(10)
   matrix3.data = new Array(22).fill(1).concat(new Array(78).fill(0))
 
-  t.equals(MaskPattern.getPenaltyN4(matrix3), 50,
+  t.equal(MaskPattern.getPenaltyN4(matrix3), 50,
     'Should return correct penalty points')
 
   t.end()

--- a/test/unit/core/mode.test.js
+++ b/test/unit/core/mode.test.js
@@ -49,10 +49,10 @@ test('Char count bits', function (t) {
     t.equal(Mode.getCharCountIndicator(Mode.KANJI, v), EXPECTED_BITS.kanji[2])
   }
 
-  t.throw(function () { Mode.getCharCountIndicator({}, 1) },
+  t.throws(function () { Mode.getCharCountIndicator({}, 1) },
     'Should throw if mode is invalid')
 
-  t.throw(function () { Mode.getCharCountIndicator(Mode.BYTE, 0) },
+  t.throws(function () { Mode.getCharCountIndicator(Mode.BYTE, 0) },
     'Should throw if version is invalid')
 
   t.end()
@@ -122,7 +122,7 @@ test('To string', function (t) {
   t.equal(Mode.toString(Mode.BYTE), 'Byte')
   t.equal(Mode.toString(Mode.KANJI), 'Kanji')
 
-  t.throw(function () { Mode.toString({}) }, 'Should throw if mode is invalid')
+  t.throws(function () { Mode.toString({}) }, 'Should throw if mode is invalid')
 
   t.end()
 })

--- a/test/unit/core/numeric-data.test.js
+++ b/test/unit/core/numeric-data.test.js
@@ -47,7 +47,7 @@ test('Numeric Data', function (t) {
 
     const bitBuffer = new BitBuffer()
     numericData.write(bitBuffer)
-    t.deepEqual(bitBuffer.buffer, data.dataBit, 'Should write correct data to buffer')
+    t.same(bitBuffer.buffer, data.dataBit, 'Should write correct data to buffer')
   })
 
   t.end()

--- a/test/unit/core/polynomial.test.js
+++ b/test/unit/core/polynomial.test.js
@@ -4,7 +4,7 @@ const Poly = require('core/polynomial')
 test('Generator polynomial', function (t) {
   const result = Poly.generateECPolynomial(0)
   t.ok(result instanceof Uint8Array, 'Should return an Uint8Array')
-  t.deepEqual(result, new Uint8Array([1]), 'Should return coeff [1] for polynomial of degree 0')
+  t.same(result, new Uint8Array([1]), 'Should return coeff [1] for polynomial of degree 0')
 
   for (let e = 2; e <= 68; e++) {
     t.equal(Poly.generateECPolynomial(e).length, e + 1, 'Should return a number of coefficients equal to (degree + 1)')

--- a/test/unit/core/qrcode.test.js
+++ b/test/unit/core/qrcode.test.js
@@ -6,7 +6,7 @@ const toSJIS = require('helper/to-sjis')
 
 test('QRCode interface', function (t) {
   t.type(QRCode.create, 'function', 'Should have "create" function')
-  t.throw(function () { QRCode.create() }, 'Should throw if no data is provided')
+  t.throws(function () { QRCode.create() }, 'Should throw if no data is provided')
   t.doesNotThrow(function () { QRCode.create('1234567') }, 'Should not throw')
 
   let qr = QRCode.create('a123456A', {
@@ -20,7 +20,7 @@ test('QRCode interface', function (t) {
   const darkModule = qr.modules.get(qr.modules.size - 8, 8)
   t.ok(darkModule, 'Should have a dark module at coords [size-8][8]')
 
-  t.throw(function () {
+  t.throws(function () {
     qr = QRCode.create({})
   }, 'Should throw if invalid data is passed')
 
@@ -84,12 +84,12 @@ test('QRCode version', function (t) {
   t.equal(qr.version, 9, 'Should create qrcode with correct version')
   t.equal(qr.errorCorrectionLevel, ECLevel.M, 'Should set correct EC level')
 
-  t.throw(function () {
+  t.throws(function () {
     qr = QRCode.create(new Array(Version.getCapacity(2, ECLevel.H)).join('a'),
       { version: 1, errorCorrectionLevel: ECLevel.H })
   }, 'Should throw if data cannot be contained with chosen version')
 
-  t.throw(function () {
+  t.throws(function () {
     qr = QRCode.create(new Array(Version.getCapacity(40, ECLevel.H) + 2).join('a'),
       { version: 40, errorCorrectionLevel: ECLevel.H })
   }, 'Should throw if data cannot be contained in a qr code')

--- a/test/unit/core/qrcode.test.js
+++ b/test/unit/core/qrcode.test.js
@@ -60,14 +60,14 @@ test('QRCode error correction', function (t) {
         qr = QRCode.create('ABCDEFG', { errorCorrectionLevel: ecValues[l].name[i] })
       }, 'Should accept errorCorrectionLevel value: ' + ecValues[l].name[i])
 
-      t.deepEqual(qr.errorCorrectionLevel, ecValues[l].level,
+      t.same(qr.errorCorrectionLevel, ecValues[l].level,
         'Should have correct errorCorrectionLevel value')
 
       t.doesNotThrow(function () {
         qr = QRCode.create('ABCDEFG', { errorCorrectionLevel: ecValues[l].name[i].toUpperCase() })
       }, 'Should accept errorCorrectionLevel value: ' + ecValues[l].name[i].toUpperCase())
 
-      t.deepEqual(qr.errorCorrectionLevel, ecValues[l].level,
+      t.same(qr.errorCorrectionLevel, ecValues[l].level,
         'Should have correct errorCorrectionLevel value')
     }
   }

--- a/test/unit/core/qrcode.test.js
+++ b/test/unit/core/qrcode.test.js
@@ -7,7 +7,7 @@ const toSJIS = require('helper/to-sjis')
 test('QRCode interface', function (t) {
   t.type(QRCode.create, 'function', 'Should have "create" function')
   t.throw(function () { QRCode.create() }, 'Should throw if no data is provided')
-  t.notThrow(function () { QRCode.create('1234567') }, 'Should not throw')
+  t.doesNotThrow(function () { QRCode.create('1234567') }, 'Should not throw')
 
   let qr = QRCode.create('a123456A', {
     version: 1,
@@ -24,11 +24,11 @@ test('QRCode interface', function (t) {
     qr = QRCode.create({})
   }, 'Should throw if invalid data is passed')
 
-  t.notThrow(function () {
+  t.doesNotThrow(function () {
     qr = QRCode.create('AAAAA00000', { version: 5 })
   }, 'Should accept data as string')
 
-  t.notThrow(function () {
+  t.doesNotThrow(function () {
     qr = QRCode.create([
       { data: 'ABCDEFG', mode: 'alphanumeric' },
       { data: 'abcdefg' },
@@ -37,7 +37,7 @@ test('QRCode interface', function (t) {
     ], { toSJISFunc: toSJIS })
   }, 'Should accept data as array of objects')
 
-  t.notThrow(function () {
+  t.doesNotThrow(function () {
     qr = QRCode.create('AAAAA00000', { errorCorrectionLevel: 'quartile' })
     qr = QRCode.create('AAAAA00000', { errorCorrectionLevel: 'q' })
   }, 'Should accept errorCorrectionLevel as string')
@@ -56,14 +56,14 @@ test('QRCode error correction', function (t) {
 
   for (let l = 0; l < ecValues.length; l++) {
     for (let i = 0; i < ecValues[l].name.length; i++) {
-      t.notThrow(function () {
+      t.doesNotThrow(function () {
         qr = QRCode.create('ABCDEFG', { errorCorrectionLevel: ecValues[l].name[i] })
       }, 'Should accept errorCorrectionLevel value: ' + ecValues[l].name[i])
 
       t.deepEqual(qr.errorCorrectionLevel, ecValues[l].level,
         'Should have correct errorCorrectionLevel value')
 
-      t.notThrow(function () {
+      t.doesNotThrow(function () {
         qr = QRCode.create('ABCDEFG', { errorCorrectionLevel: ecValues[l].name[i].toUpperCase() })
       }, 'Should accept errorCorrectionLevel value: ' + ecValues[l].name[i].toUpperCase())
 
@@ -94,7 +94,7 @@ test('QRCode version', function (t) {
       { version: 40, errorCorrectionLevel: ECLevel.H })
   }, 'Should throw if data cannot be contained in a qr code')
 
-  t.notThrow(function () {
+  t.doesNotThrow(function () {
     qr = QRCode.create('abcdefg', { version: 'invalid' })
   }, 'Should use best version if the one provided is invalid')
 

--- a/test/unit/core/reed-solomon-encoder.test.js
+++ b/test/unit/core/reed-solomon-encoder.test.js
@@ -26,7 +26,7 @@ test('Reed-Solomon encoder', function (t) {
   t.notOk(enc.genPoly, 'Should not create a generator polynomial if degree is 0')
 
   enc = new RS(1)
-  t.deepEqual(enc.encode(new Uint8Array([0])), new Uint8Array([0]),
+  t.same(enc.encode(new Uint8Array([0])), new Uint8Array([0]),
     'Should return correct buffer')
 
   t.end()

--- a/test/unit/core/reed-solomon-encoder.test.js
+++ b/test/unit/core/reed-solomon-encoder.test.js
@@ -5,7 +5,7 @@ test('Reed-Solomon encoder', function (t) {
   let enc = new RS()
 
   t.notOk(enc.genPoly, 'Should have an undefined generator polynomial')
-  t.throw(function () { enc.encode([]) }, 'Should throw if generator polynomial is undefined')
+  t.throws(function () { enc.encode([]) }, 'Should throw if generator polynomial is undefined')
 
   enc.initialize(2)
   t.equal(enc.degree, 2, 'Should set correct degree value')

--- a/test/unit/core/reed-solomon-encoder.test.js
+++ b/test/unit/core/reed-solomon-encoder.test.js
@@ -20,7 +20,7 @@ test('Reed-Solomon encoder', function (t) {
   t.ok(genPoly, 'Generator polynomial should be defined')
 
   enc.initialize(3)
-  t.notEqual(enc.genPoly, genPoly, 'Should reinitialize the generator polynomial')
+  t.not(enc.genPoly, genPoly, 'Should reinitialize the generator polynomial')
 
   enc = new RS(0)
   t.notOk(enc.genPoly, 'Should not create a generator polynomial if degree is 0')

--- a/test/unit/core/segments.test.js
+++ b/test/unit/core/segments.test.js
@@ -186,7 +186,7 @@ test('Segments from array', function (t) {
   t.deepEqual(Segments.fromArray([{}]), [],
     'Should return an empty array')
 
-  t.throw(function () { Segments.fromArray([{ data: 'ABCDE', mode: 'numeric' }]) },
+  t.throws(function () { Segments.fromArray([{ data: 'ABCDE', mode: 'numeric' }]) },
     'Should throw if segment cannot be encoded with specified mode')
 
   t.deepEqual(

--- a/test/unit/core/segments.test.js
+++ b/test/unit/core/segments.test.js
@@ -163,33 +163,33 @@ const kanjiTestData = [
 testData = testData.concat(kanjiTestData)
 
 test('Segments from array', function (t) {
-  t.deepEqual(
+  t.same(
     Segments.fromArray(['abcdef', '12345']),
     [new ByteData('abcdef'), new NumericData('12345')],
     'Should return correct segment from array of string')
 
-  t.deepEqual(
+  t.same(
     Segments.fromArray([{ data: 'abcdef', mode: Mode.BYTE }, { data: '12345', mode: Mode.NUMERIC }]),
     [new ByteData('abcdef'), new NumericData('12345')],
     'Should return correct segment from array of objects')
 
-  t.deepEqual(
+  t.same(
     Segments.fromArray([{ data: 'abcdef', mode: 'byte' }, { data: '12345', mode: 'numeric' }]),
     [new ByteData('abcdef'), new NumericData('12345')],
     'Should return correct segment from array of objects if mode is specified as string')
 
-  t.deepEqual(
+  t.same(
     Segments.fromArray([{ data: 'abcdef' }, { data: '12345' }]),
     [new ByteData('abcdef'), new NumericData('12345')],
     'Should return correct segment from array of objects if mode is not specified')
 
-  t.deepEqual(Segments.fromArray([{}]), [],
+  t.same(Segments.fromArray([{}]), [],
     'Should return an empty array')
 
   t.throws(function () { Segments.fromArray([{ data: 'ABCDE', mode: 'numeric' }]) },
     'Should throw if segment cannot be encoded with specified mode')
 
-  t.deepEqual(
+  t.same(
     Segments.fromArray([{ data: '０１２３', mode: Mode.KANJI }]), [new ByteData('０１２３')],
     'Should use Byte mode if kanji support is disabled')
 
@@ -197,12 +197,12 @@ test('Segments from array', function (t) {
 })
 
 test('Segments optimization', function (t) {
-  t.deepEqual(Segments.fromString('乂ЁЖ', 1), Segments.fromArray([{ data: '乂ЁЖ', mode: 'byte' }]),
+  t.same(Segments.fromString('乂ЁЖ', 1), Segments.fromArray([{ data: '乂ЁЖ', mode: 'byte' }]),
     'Should use Byte mode if Kanji support is disabled')
 
   Utils.setToSJISFunction(toSJIS)
   testData.forEach(function (data) {
-    t.deepEqual(Segments.fromString(data.input, 1), Segments.fromArray(data.result))
+    t.same(Segments.fromString(data.input, 1), Segments.fromArray(data.result))
   })
 
   t.end()
@@ -215,7 +215,7 @@ test('Segments raw split', function (t) {
     new NumericData('123')
   ]
 
-  t.deepEqual(Segments.rawSplit('abcDEF123'), splitted)
+  t.same(Segments.rawSplit('abcDEF123'), splitted)
 
   t.end()
 })

--- a/test/unit/core/utils.test.js
+++ b/test/unit/core/utils.test.js
@@ -51,7 +51,7 @@ test('BCH Digit', function (t) {
 })
 
 test('Set/Get SJIS function', function (t) {
-  t.throw(function () { Utils.setToSJISFunction() },
+  t.throws(function () { Utils.setToSJISFunction() },
     'Should throw if param is not a function')
 
   t.notOk(Utils.isKanjiModeEnabled(),

--- a/test/unit/renderer/canvas.test.js
+++ b/test/unit/renderer/canvas.test.js
@@ -48,7 +48,7 @@ test('CanvasRenderer render', function (t) {
 
   global.document = undefined
 
-  t.throw(function () { canvasEl = CanvasRenderer.render(sampleQrData) },
+  t.throws(function () { canvasEl = CanvasRenderer.render(sampleQrData) },
     'Should throw if canvas cannot be created')
 
   t.end()

--- a/test/unit/renderer/canvas.test.js
+++ b/test/unit/renderer/canvas.test.js
@@ -26,13 +26,13 @@ test('CanvasRenderer render', function (t) {
   const sampleQrData = QRCode.create('sample text', { version: 2 })
   let canvasEl
 
-  t.notThrow(function () { canvasEl = CanvasRenderer.render(sampleQrData) },
+  t.doesNotThrow(function () { canvasEl = CanvasRenderer.render(sampleQrData) },
     'Should not throw if canvas is not provided')
 
   t.ok(canvasEl instanceof Canvas,
     'Should return a new canvas object')
 
-  t.notThrow(function () {
+  t.doesNotThrow(function () {
     canvasEl = CanvasRenderer.render(sampleQrData, {
       margin: 10,
       scale: 1
@@ -58,10 +58,10 @@ test('CanvasRenderer render to provided canvas', function (t) {
   const sampleQrData = QRCode.create('sample text', { version: 2 })
   const canvasEl = createCanvas(200, 200)
 
-  t.notThrow(function () { CanvasRenderer.render(sampleQrData, canvasEl) },
+  t.doesNotThrow(function () { CanvasRenderer.render(sampleQrData, canvasEl) },
     'Should not throw with only qrData and canvas param')
 
-  t.notThrow(function () {
+  t.doesNotThrow(function () {
     CanvasRenderer.render(sampleQrData, canvasEl, {
       margin: 10,
       scale: 1
@@ -91,10 +91,10 @@ test('CanvasRenderer renderToDataURL', function (t) {
   const sampleQrData = QRCode.create('sample text', { version: 2 })
   let url
 
-  t.notThrow(function () { url = CanvasRenderer.renderToDataURL(sampleQrData) },
+  t.doesNotThrow(function () { url = CanvasRenderer.renderToDataURL(sampleQrData) },
     'Should not throw if canvas is not provided')
 
-  t.notThrow(function () {
+  t.doesNotThrow(function () {
     url = CanvasRenderer.renderToDataURL(sampleQrData, {
       margin: 10,
       scale: 1,
@@ -121,11 +121,11 @@ test('CanvasRenderer renderToDataURL to provided canvas', function (t) {
   const canvasEl = createCanvas(200, 200)
   let url
 
-  t.notThrow(function () {
+  t.doesNotThrow(function () {
     url = CanvasRenderer.renderToDataURL(sampleQrData, canvasEl)
   }, 'Should not throw with only qrData and canvas param')
 
-  t.notThrow(function () {
+  t.doesNotThrow(function () {
     url = CanvasRenderer.renderToDataURL(sampleQrData, canvasEl, {
       margin: 10,
       scale: 1,

--- a/test/unit/renderer/png.test.js
+++ b/test/unit/renderer/png.test.js
@@ -26,7 +26,7 @@ test('PNG render', function (t) {
   const sampleQrData = QRCode.create('sample text', { version: 2 })
   let png
 
-  t.notThrow(function () { png = PngRenderer.render(sampleQrData) },
+  t.doesNotThrow(function () { png = PngRenderer.render(sampleQrData) },
     'Should not throw with only qrData param')
 
   t.ok(png instanceof PNG,
@@ -39,7 +39,7 @@ test('PNG render', function (t) {
   t.equal(png.width, (25 + 4 * 2) * 4,
     'Should have correct size')
 
-  t.notThrow(function () {
+  t.doesNotThrow(function () {
     png = PngRenderer.render(sampleQrData, {
       margin: 10,
       scale: 1
@@ -128,11 +128,11 @@ test('PNG renderToFile', function (t) {
 test('PNG renderToFileStream', function (t) {
   const sampleQrData = QRCode.create('sample text', { version: 2 })
 
-  t.notThrow(function () {
+  t.doesNotThrow(function () {
     PngRenderer.renderToFileStream(new StreamMock(), sampleQrData)
   }, 'Should not throw with only qrData param')
 
-  t.notThrow(function () {
+  t.doesNotThrow(function () {
     PngRenderer.renderToFileStream(new StreamMock(), sampleQrData, {
       margin: 10,
       scale: 1

--- a/test/unit/renderer/terminal.test.js
+++ b/test/unit/renderer/terminal.test.js
@@ -13,10 +13,10 @@ test('TerminalRenderer render big', function (t) {
   const sampleQrData = QRCode.create('sample text', { version: 2 })
   let str
 
-  t.notThrow(function () { str = TerminalRenderer.render(sampleQrData) },
+  t.doesNotThrow(function () { str = TerminalRenderer.render(sampleQrData) },
     'Should not throw with only qrData param')
 
-  t.notThrow(function () {
+  t.doesNotThrow(function () {
     str = TerminalRenderer.render(sampleQrData, {
       margin: 10,
       scale: 1
@@ -26,7 +26,7 @@ test('TerminalRenderer render big', function (t) {
   t.type(str, 'string',
     'Should return a string')
 
-  t.notThrow(function () {
+  t.doesNotThrow(function () {
     str = TerminalRenderer.render(sampleQrData, { inverse: true })
   }, 'Should not throw with inverse options')
 
@@ -42,10 +42,10 @@ test('TerminalRenderer render small', function (t) {
   let calledCallback = false
   const callback = function () { calledCallback = true }
 
-  t.notThrow(function () { str = TerminalRenderer.render(sampleQrData) },
+  t.doesNotThrow(function () { str = TerminalRenderer.render(sampleQrData) },
     'Should not throw with only qrData param')
 
-  t.notThrow(function () {
+  t.doesNotThrow(function () {
     str = TerminalRenderer.render(sampleQrData, {
       margin: 10,
       scale: 1,
@@ -53,7 +53,7 @@ test('TerminalRenderer render small', function (t) {
     })
   }, 'Should not throw with options param and without callback')
 
-  t.notThrow(function () {
+  t.doesNotThrow(function () {
     str = TerminalRenderer.render(sampleQrData, {
       margin: 10,
       scale: 1,
@@ -68,7 +68,7 @@ test('TerminalRenderer render small', function (t) {
   t.equal(calledCallback, true, 'string',
     'Should call a callback')
 
-  t.notThrow(function () {
+  t.doesNotThrow(function () {
     str = TerminalRenderer.render(sampleQrData, { small: true, inverse: true })
   }, 'Should not throw with inverse options')
 

--- a/test/unit/renderer/utf8.test.js
+++ b/test/unit/renderer/utf8.test.js
@@ -15,10 +15,10 @@ test('Utf8Renderer render', function (t) {
   const sampleQrData = QRCode.create('sample text', { version: 2 })
   let str
 
-  t.notThrow(function () { str = Utf8Renderer.render(sampleQrData) },
+  t.doesNotThrow(function () { str = Utf8Renderer.render(sampleQrData) },
     'Should not throw with only qrData param')
 
-  t.notThrow(function () {
+  t.doesNotThrow(function () {
     str = Utf8Renderer.render(sampleQrData, {
       margin: 10,
       scale: 1

--- a/test/unit/renderer/utils.test.js
+++ b/test/unit/renderer/utils.test.js
@@ -17,7 +17,7 @@ test('Utils getOptions', function (t) {
   t.ok(Utils.getOptions,
     'getOptions should be defined')
 
-  t.deepEqual(Utils.getOptions(), defaultOptions,
+  t.same(Utils.getOptions(), defaultOptions,
     'Should return default options if called without param')
 
   t.equal(Utils.getOptions({ scale: 8 }).scale, 8,
@@ -35,14 +35,14 @@ test('Utils getOptions', function (t) {
   t.equal(Utils.getOptions({ margin: 20 }).margin, 20,
     'Should return correct margin value')
 
-  t.deepEqual(Utils.getOptions({ color: { dark: '#fff', light: '#000000' } }).color,
+  t.same(Utils.getOptions({ color: { dark: '#fff', light: '#000000' } }).color,
     {
       dark: { r: 255, g: 255, b: 255, a: 255, hex: '#ffffff' },
       light: { r: 0, g: 0, b: 0, a: 255, hex: '#000000' }
     },
     'Should return correct colors value from strings')
 
-  t.deepEqual(Utils.getOptions({ color: { dark: 111, light: 999 } }).color,
+  t.same(Utils.getOptions({ color: { dark: 111, light: 999 } }).color,
     {
       dark: { r: 17, g: 17, b: 17, a: 255, hex: '#111111' },
       light: { r: 153, g: 153, b: 153, a: 255, hex: '#999999' }

--- a/test/unit/renderer/utils.test.js
+++ b/test/unit/renderer/utils.test.js
@@ -49,10 +49,10 @@ test('Utils getOptions', function (t) {
     },
     'Should return correct colors value from numbers')
 
-  t.throw(function () { Utils.getOptions({ color: { dark: true } }) },
+  t.throws(function () { Utils.getOptions({ color: { dark: true } }) },
     'Should throw if color is not a string')
 
-  t.throw(function () { Utils.getOptions({ color: { dark: '#aa' } }) },
+  t.throws(function () { Utils.getOptions({ color: { dark: '#aa' } }) },
     'Should throw if color is not in a valid hex format')
 
   t.end()


### PR DESCRIPTION
I replaced all the deprecated functions in `tap` tests. This keeps the tests output nice and tidy and it allows to upgrade to the latest `tap` release (v20 for NodeJS 18+, or v21 for NodeJS 20+) in the future.

Test report on `master` branch:

```
Suites:   ​33 passed​, ​33 of 33 completed
Asserts:  ​​​6187 passed​, ​of 6187
​Time:​   ​3s
```

Test report after replacing deprecated functions:

```
Suites:   ​33 passed​, ​33 of 33 completed
Asserts:  ​​​6187 passed​, ​of 6187
​Time:​   ​2s
```