### PR TITLE
Remove incorrect argument from the `TerminalRenderer render small` test

### DIFF
--- a/test/unit/renderer/terminal.test.js
+++ b/test/unit/renderer/terminal.test.js
@@ -65,7 +65,7 @@ test('TerminalRenderer render small', function (t) {
   t.type(str, 'string',
     'Should return a string')
 
-  t.equal(calledCallback, true, 'string',
+  t.equal(calledCallback, true,
     'Should call a callback')
 
   t.notThrow(function () {


### PR DESCRIPTION
The test `TerminalRenderer render small` calls the `t.equal()` function with an additional argument which should not be there.

Running this test with `tap@20` will result in a failed test:

```
TerminalRenderer render small > Cannot create property 'bail' on string 'Should call a callback'
```

```
 FAIL  test/unit/renderer/terminal.test.js 1 failed of 11 1.483s
 ✖  TerminalRenderer render small > Cannot create property 'bail' on string 'Should call a callback'
    test/unit/renderer/terminal.test.js                                               
    65   t.type(str, 'string',                                                        
    66     'Should return a string')                                                  
    67                                                                                
    68   t.equal(calledCallback, true, 'string',                                      
    ━━━━━━━┛                                                                          
    69     'Should call a callback')                                                  
    70                                                                                
    71   t.doesNotThrow(function () {                                                 
    72     str = TerminalRenderer.render(sampleQrData, { small: true, inverse: true })
    type: TypeError
    tapCaught: testFunctionThrow
    Test.<anonymous> (test/unit/renderer/terminal.test.js:68:5)
```
